### PR TITLE
Reduce memory usage of eachMapping w/ loop

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -143,18 +143,24 @@ SourceMapConsumer.prototype.eachMapping =
     }
 
     var sourceRoot = this.sourceRoot;
-    mappings.map(function (mapping) {
-      var source = mapping.source === null ? null : this._sources.at(mapping.source);
-      source = util.computeSourceURL(sourceRoot, source, this._sourceMapURL);
-      return {
+    var boundCallback = aCallback.bind(context);
+    var names = this._names;
+    var sources = this._sources;
+    var sourceMapURL = this._sourceMapURL;
+
+    for (var i = 0, n = mappings.length; i < n; i++) {
+      var mapping = mappings[i];
+      var source = mapping.source === null ? null : sources.at(mapping.source);
+      source = util.computeSourceURL(sourceRoot, source, sourceMapURL);
+      boundCallback({
         source: source,
         generatedLine: mapping.generatedLine,
         generatedColumn: mapping.generatedColumn,
         originalLine: mapping.originalLine,
         originalColumn: mapping.originalColumn,
-        name: mapping.name === null ? null : this._names.at(mapping.name)
-      };
-    }, this).forEach(aCallback, context);
+        name: mapping.name === null ? null : names.at(mapping.name)
+      });
+    }
   };
 
 /**


### PR DESCRIPTION
Avoid creating arrays of intermediate values to pass to `aCallback`, by
refactoring the .map + .forEach combination to a single loop that that
creates the options object and immediately passes it to aCallback.

This reduces memory usage, because engine no longer has to hold all the
options objects in memory, each of the created objects is free to be gcd
once the loop continues to next item.

When the looped-over array `mappings` is very large (e.g. >40k items),
the operation may even crash with out of memory exception without this
patch.