### PR TITLE
Fix `package.json#typings` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,5 @@
     "doctoc": "^0.15.0",
     "webpack": "^1.12.0"
   },
-  "typings": "source-map"
+  "typings": "source-map.d.ts"
 }


### PR DESCRIPTION
Fixes: https://stackoverflow.com/questions/63124462/how-to-fix-file-node-modules-dotenv-types-not-found-error-coming-from-j