### PR TITLE
Change post-increment/decrement to pre-increment/decrement

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -513,15 +513,15 @@ BasicSourceMapConsumer.prototype._parseMappings =
     let subarrayStart = 0;
     while (index < length) {
       if (aStr.charAt(index) === ';') {
-        generatedLine++;
-        index++;
+        ++generatedLine;
+        ++index;
         previousGeneratedColumn = 0;
 
         sortGenerated(generatedMappings, subarrayStart);
         subarrayStart = generatedMappings.length;
       }
       else if (aStr.charAt(index) === ',') {
-        index++;
+        ++index;
       }
       else {
         mapping = new Mapping();

--- a/lib/source-map-generator.js
+++ b/lib/source-map-generator.js
@@ -331,7 +331,7 @@ SourceMapGenerator.prototype._serializeMappings =
         previousGeneratedColumn = 0;
         while (mapping.generatedLine !== previousGeneratedLine) {
           next += ';';
-          previousGeneratedLine++;
+          ++previousGeneratedLine;
         }
       }
       else {

--- a/lib/source-node.js
+++ b/lib/source-node.js
@@ -114,7 +114,7 @@ SourceNode.fromStringWithSourceMap =
       // Each line is added as separate string.
       while (lastGeneratedLine < mapping.generatedLine) {
         node.add(shiftNextLine());
-        lastGeneratedLine++;
+        ++lastGeneratedLine;
       }
       if (lastGeneratedColumn < mapping.generatedColumn) {
         var nextLine = remainingLines[remainingLinesIndex] || '';
@@ -378,7 +378,7 @@ SourceNode.prototype.toStringWithSourceMap = function SourceNode_toStringWithSou
     }
     for (var idx = 0, length = chunk.length; idx < length; idx++) {
       if (chunk.charCodeAt(idx) === NEWLINE_CODE) {
-        generated.line++;
+        ++generated.line;
         generated.column = 0;
         // Mappings end at eol
         if (idx + 1 === length) {
@@ -399,7 +399,7 @@ SourceNode.prototype.toStringWithSourceMap = function SourceNode_toStringWithSou
           });
         }
       } else {
-        generated.column++;
+        ++generated.column;
       }
     }
   });

--- a/lib/util.js
+++ b/lib/util.js
@@ -138,7 +138,7 @@ var normalize = lruMemoize(function normalize(aPath) {
     } else {
       parts.push(path.slice(start, i));
       while (i < path.length && path[i] === "/") {
-        i++;
+        ++i;
       }
     }
   }
@@ -148,7 +148,7 @@ var normalize = lruMemoize(function normalize(aPath) {
     if (part === '.') {
       parts.splice(i, 1);
     } else if (part === '..') {
-      up++;
+      ++up;
     } else if (up > 0) {
       if (part === '') {
         // The first part is blank if the path is absolute. Trying to go
@@ -158,7 +158,7 @@ var normalize = lruMemoize(function normalize(aPath) {
         up = 0;
       } else {
         parts.splice(i, 2);
-        up--;
+        --up;
       }
     }
   }


### PR DESCRIPTION
The pre-increment/decrement work more than two times faster post-increment/decrement.

```js
++i;       // x 229,089,485 ops/sec ±21.37% (42 runs sampled)
i++;       // x  97,799,379 ops/sec ±0.42%  (64 runs sampled)
i += 1;    // x 100,100,815 ops/sec ±0.41%  (63 runs sampled)
i = 1 + i; // x 101,667,846 ops/sec ±0.35%  (64 runs sampled)
i = i + 1; // x 103,011,980 ops/sec ±0.34%  (64 runs sampled)
```

```js
--i;       // x 242,213,781 ops/sec ±21.40% (42 runs sampled)
i--;       // x  96,831,143 ops/sec ±1.82%  (62 runs sampled)
i -= 1;    // x 101,432,184 ops/sec ±0.44%  (62 runs sampled)
i = i - 1; // x 103,164,340 ops/sec ±0.61%  (65 runs sampled)
```

- https://www.measurethat.net/Benchmarks/Show/15209/0/pre-increment-increment-vs-post-increment-increment-vs
- https://www.measurethat.net/Benchmarks/Show/15211/0/pre-decrement-vs-post-decrement-vs-assignment-operator


