### PR TITLE
Remove cleanComments optimization

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
     "webpack": "^1.12.0"
   },
   "clean-publish": {
-    "cleanDocs": true,
-    "cleanComments": true
+    "cleanDocs": true
   },
   "typings": "source-map.d.ts"
 }


### PR DESCRIPTION
`cleanComments` is not very stable and safe for now.

Sorry, it broke 1.0 😓

Let’s release 1.0.1 without it.