### PR TITLE
Fix TS2306 “not a module” errors in type definitions

### DIFF
--- a/lib/source-map-consumer.d.ts
+++ b/lib/source-map-consumer.d.ts
@@ -1,0 +1,1 @@
+export { SourceMapConsumer } from '..';

--- a/lib/source-map-generator.d.ts
+++ b/lib/source-map-generator.d.ts
@@ -1,0 +1,1 @@
+export { SourceMapGenerator } from '..';

--- a/lib/source-node.d.ts
+++ b/lib/source-node.d.ts
@@ -1,0 +1,1 @@
+export { SourceNode } from '..';

--- a/source-map.d.ts
+++ b/source-map.d.ts
@@ -1,115 +1,98 @@
-declare module 'source-map-js' { 
-    export interface StartOfSourceMap {
-        file?: string;
-        sourceRoot?: string;
-    }
-
-    export interface RawSourceMap extends StartOfSourceMap {
-        version: string;
-        sources: string[];
-        names: string[];
-        sourcesContent?: string[];
-        mappings: string;
-    }
-
-    export interface Position {
-        line: number;
-        column: number;
-    }
-
-    export interface LineRange extends Position {
-        lastColumn: number;
-    }
-
-    export interface FindPosition extends Position {
-        // SourceMapConsumer.GREATEST_LOWER_BOUND or SourceMapConsumer.LEAST_UPPER_BOUND
-        bias?: number;
-    }
-
-    export interface SourceFindPosition extends FindPosition {
-        source: string;
-    }
-
-    export interface MappedPosition extends Position {
-        source: string;
-        name?: string;
-    }
-
-    export interface MappingItem {
-        source: string;
-        generatedLine: number;
-        generatedColumn: number;
-        originalLine: number;
-        originalColumn: number;
-        name: string;
-    }
-
-    export class SourceMapConsumer {
-        static GENERATED_ORDER: number;
-        static ORIGINAL_ORDER: number;
-
-        static GREATEST_LOWER_BOUND: number;
-        static LEAST_UPPER_BOUND: number;
-
-        constructor(rawSourceMap: RawSourceMap);
-        computeColumnSpans(): void;
-        originalPositionFor(generatedPosition: FindPosition): MappedPosition;
-        generatedPositionFor(originalPosition: SourceFindPosition): LineRange;
-        allGeneratedPositionsFor(originalPosition: MappedPosition): Position[];
-        hasContentsOfAllSources(): boolean;
-        sourceContentFor(source: string, returnNullOnMissing?: boolean): string;
-        eachMapping(callback: (mapping: MappingItem) => void, context?: any, order?: number): void;
-    }
-
-    export interface Mapping {
-        generated: Position;
-        original: Position;
-        source: string;
-        name?: string;
-    }
-
-    export class SourceMapGenerator {
-        constructor(startOfSourceMap?: StartOfSourceMap);
-        static fromSourceMap(sourceMapConsumer: SourceMapConsumer): SourceMapGenerator;
-        addMapping(mapping: Mapping): void;
-        setSourceContent(sourceFile: string, sourceContent: string): void;
-        applySourceMap(sourceMapConsumer: SourceMapConsumer, sourceFile?: string, sourceMapPath?: string): void;
-        toString(): string;
-    }
-
-    export interface CodeWithSourceMap {
-        code: string;
-        map: SourceMapGenerator;
-    }
-
-    export class SourceNode {
-        constructor();
-        constructor(line: number, column: number, source: string);
-        constructor(line: number, column: number, source: string, chunk?: string, name?: string);
-        static fromStringWithSourceMap(code: string, sourceMapConsumer: SourceMapConsumer, relativePath?: string): SourceNode;
-        add(chunk: string): void;
-        prepend(chunk: string): void;
-        setSourceContent(sourceFile: string, sourceContent: string): void;
-        walk(fn: (chunk: string, mapping: MappedPosition) => void): void;
-        walkSourceContents(fn: (file: string, content: string) => void): void;
-        join(sep: string): SourceNode;
-        replaceRight(pattern: string, replacement: string): SourceNode;
-        toString(): string;
-        toStringWithSourceMap(startOfSourceMap?: StartOfSourceMap): CodeWithSourceMap;
-    }
+export interface StartOfSourceMap {
+    file?: string;
+    sourceRoot?: string;
 }
 
-declare module 'source-map-js/lib/source-map-generator' {
-    import { SourceMapGenerator } from 'source-map-js'
-    export { SourceMapGenerator }
+export interface RawSourceMap extends StartOfSourceMap {
+    version: string;
+    sources: string[];
+    names: string[];
+    sourcesContent?: string[];
+    mappings: string;
 }
 
-declare module 'source-map-js/lib/source-map-consumer' {
-    import { SourceMapConsumer } from 'source-map-js'
-    export { SourceMapConsumer }
+export interface Position {
+    line: number;
+    column: number;
 }
 
-declare module 'source-map-js/lib/source-node' {
-    import { SourceNode } from 'source-map-js'
-    export { SourceNode }
+export interface LineRange extends Position {
+    lastColumn: number;
+}
+
+export interface FindPosition extends Position {
+    // SourceMapConsumer.GREATEST_LOWER_BOUND or SourceMapConsumer.LEAST_UPPER_BOUND
+    bias?: number;
+}
+
+export interface SourceFindPosition extends FindPosition {
+    source: string;
+}
+
+export interface MappedPosition extends Position {
+    source: string;
+    name?: string;
+}
+
+export interface MappingItem {
+    source: string;
+    generatedLine: number;
+    generatedColumn: number;
+    originalLine: number;
+    originalColumn: number;
+    name: string;
+}
+
+export class SourceMapConsumer {
+    static GENERATED_ORDER: number;
+    static ORIGINAL_ORDER: number;
+
+    static GREATEST_LOWER_BOUND: number;
+    static LEAST_UPPER_BOUND: number;
+
+    constructor(rawSourceMap: RawSourceMap);
+    computeColumnSpans(): void;
+    originalPositionFor(generatedPosition: FindPosition): MappedPosition;
+    generatedPositionFor(originalPosition: SourceFindPosition): LineRange;
+    allGeneratedPositionsFor(originalPosition: MappedPosition): Position[];
+    hasContentsOfAllSources(): boolean;
+    sourceContentFor(source: string, returnNullOnMissing?: boolean): string;
+    eachMapping(callback: (mapping: MappingItem) => void, context?: any, order?: number): void;
+}
+
+export interface Mapping {
+    generated: Position;
+    original: Position;
+    source: string;
+    name?: string;
+}
+
+export class SourceMapGenerator {
+    constructor(startOfSourceMap?: StartOfSourceMap);
+    static fromSourceMap(sourceMapConsumer: SourceMapConsumer): SourceMapGenerator;
+    addMapping(mapping: Mapping): void;
+    setSourceContent(sourceFile: string, sourceContent: string): void;
+    applySourceMap(sourceMapConsumer: SourceMapConsumer, sourceFile?: string, sourceMapPath?: string): void;
+    toString(): string;
+}
+
+export interface CodeWithSourceMap {
+    code: string;
+    map: SourceMapGenerator;
+}
+
+export class SourceNode {
+    constructor();
+    constructor(line: number, column: number, source: string);
+    constructor(line: number, column: number, source: string, chunk?: string, name?: string);
+    static fromStringWithSourceMap(code: string, sourceMapConsumer: SourceMapConsumer, relativePath?: string): SourceNode;
+    add(chunk: string): void;
+    prepend(chunk: string): void;
+    setSourceContent(sourceFile: string, sourceContent: string): void;
+    walk(fn: (chunk: string, mapping: MappedPosition) => void): void;
+    walkSourceContents(fn: (file: string, content: string) => void): void;
+    join(sep: string): SourceNode;
+    replaceRight(pattern: string, replacement: string): SourceNode;
+    toString(): string;
+    toStringWithSourceMap(startOfSourceMap?: StartOfSourceMap): CodeWithSourceMap;
 }


### PR DESCRIPTION
Fixes TypeScript errors like this when substituting source-map-js for source-map using pnpm overrides.

    node_modules/.pnpm/css-minimizer-webpack-plugin@4.2.2_dpcjkp5o5ztxuvt4quwwvenemi/node_modules/css-minimizer-webpack-plugin/types/index.d.ts:141:28 - error TS2306: File '/srv/zulip/node_modules/.pnpm/source-map-js@1.0.2/node_modules/source-map-js/source-map.d.ts' is not a module.

    141 type RawSourceMap = import("source-map").RawSourceMap;
                                   ~~~~~~~~~~~~

- Fixes #24.