### PR TITLE
Use sourceContents when non-null, even if it's an empty string

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -1066,7 +1066,7 @@ IndexedSourceMapConsumer.prototype.sourceContentFor =
       var section = this._sections[i];
 
       var content = section.consumer.sourceContentFor(aSource, true);
-      if (content) {
+      if (content || content === '') {
         return content;
       }
     }


### PR DESCRIPTION
When using an optimizing compiler, it may be that all the functions in a
file have been inlined into their call sites, leaving the file empty.
But there are still references to that file in other modules, whose source
maps will contain `sources` and `sourceContents` entries for the empty file.

The `sourceContents` for the empty files is `""`, the empty string.
That's falsy in JavaScript which causes this check to wrongly fail,
leading to an attempt to open the formerly empty but now missing file,
breaking compilation.

This tweaks the check to allow an empty but non-`null` `sourceContents`.

**Background:**

In my case the optimizing compiler in question is a ClojureScript compiler
https://github.com/thheller/shadow-cljs, which wraps the Google Closure compiler.
The ClojureScript code is used as a library by our JS and TS code, and this issue
is blocking getting source maps working for optimized release builds.
