### PR TITLE
perf: reuse segment array to avoid
  allocations per mapping

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -546,7 +546,10 @@ BasicSourceMapConsumer.prototype._parseMappings =
     var index = 0;
     var temp = {};
     var generatedMappings = [];
-    var mapping, segment, value, charCode;
+    var mapping, value, charCode;
+    // Reuse segment array to avoid allocations per mapping
+    var segment = [0, 0, 0, 0, 0];
+    var segmentLength = 0;
 
     let subarrayStart = 0;
     while (index < length) {
@@ -567,7 +570,7 @@ BasicSourceMapConsumer.prototype._parseMappings =
         mapping.generatedLine = generatedLine;
 
         // Decode VLQ values until we hit a separator
-        segment = [];
+        segmentLength = 0;
         while (index < length) {
           charCode = aStr.charCodeAt(index);
           if (charCode === 44 || charCode === 59) { // ',' or ';'
@@ -577,20 +580,20 @@ BasicSourceMapConsumer.prototype._parseMappings =
           value = vlqTable[charCode];
           if (value !== undefined) {
             index++;
-            segment.push(value);
+            segment[segmentLength++] = value;
           } else {
             base64VLQ.decode(aStr, index, temp);
             value = temp.value;
             index = temp.rest;
-            segment.push(value);
+            segment[segmentLength++] = value;
           }
         }
 
-        if (segment.length === 2) {
+        if (segmentLength === 2) {
           throw new Error('Found a source, but no line and column');
         }
 
-        if (segment.length === 3) {
+        if (segmentLength === 3) {
           throw new Error('Found a source and line, but no column');
         }
 
@@ -598,7 +601,7 @@ BasicSourceMapConsumer.prototype._parseMappings =
         mapping.generatedColumn = previousGeneratedColumn + segment[0];
         previousGeneratedColumn = mapping.generatedColumn;
 
-        if (segment.length > 1) {
+        if (segmentLength > 1) {
           // Original source.
           mapping.source = previousSource + segment[1];
           previousSource += segment[1];
@@ -613,7 +616,7 @@ BasicSourceMapConsumer.prototype._parseMappings =
           mapping.originalColumn = previousOriginalColumn + segment[3];
           previousOriginalColumn = mapping.originalColumn;
 
-          if (segment.length > 4) {
+          if (segmentLength > 4) {
             // Original name.
             mapping.name = previousName + segment[4];
             previousName += segment[4];


### PR DESCRIPTION
## Summary

Replace per-mapping `segment = []` + `segment.push(value)` with a reused 5-element scratch array and a `segmentLength` counter. Eliminates one allocation per mapping (millions on real source maps), reducing GC pressure during parsing.

Touches `lib/source-map-consumer.js` only.

## Conflicts

Per pr-stack-review.md, conflicts with #32 / #37 / #38 — all rewrite the inner segment-decode loop. Whichever lands first wins; the rest need rebases. Note: this PR is the **last** in the recommended merge order from the review (`#34, #40 → #36 → #35 → #32 + #38 → #37 → #33 → #39`), since segment-array reuse interacts with whatever shape the loop ends up in.

## Bench (jridgewell, two-process)

`scripts/bench-diff.sh main` on `preact.js.map`:

| Suite | Op | Δ |
| --- | --- | --- |
| Init speed | `encoded JSON input` | **+4.8%** |
| Init speed | `encoded Object input` | **+5.2%** |
| Trace speed (random) | `encoded originalPositionFor` | +2.9% |
| Trace speed (ascending) | `encoded originalPositionFor` | +0.5% |
| Generated Positions init | `encoded generatedPositionFor` | **+6.6%** |
| Generated Positions speed | `encoded generatedPositionFor` | −0.8% |
| Adding speed | `addMapping` | +5.2% |
| Generate speed | `encoded output` | +1.8% |

Mean +3.29%. Wins concentrated on parse-time benches as expected.

## Validation

- `yarn test`: pass (8 pre-existing `# TODO` failures, unchanged from `main`).
- `yarn test:coverage`: 98.07 / 97.08 / 96.58 — meets thresholds.

## Caveat (from pr-stack-review)

Reuse is only safe because `segment` is never retained outside the iteration. If a future change captures `segment` in a closure or stores it on a mapping object, this would silently break — verify before adding such code.