### PR TITLE
perf: inline base64 encode lookup
  in VLQ encoder

### DIFF
--- a/lib/base64-vlq.js
+++ b/lib/base64-vlq.js
@@ -37,6 +37,9 @@
 
 var base64 = require('./base64');
 
+// Inlined base64 encode lookup for performance (avoids function call + bounds check)
+var base64Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
 // A single base 64 digit can contain 6 bits of data. For the base 64 variable
 // length quantities we use in the source map spec, the first bit is the sign,
 // the next four bits are the actual value, and the 6th bit is the
@@ -103,7 +106,7 @@ exports.encode = function base64VLQ_encode(aValue) {
       // continuation bit is marked.
       digit |= VLQ_CONTINUATION_BIT;
     }
-    encoded += base64.encode(digit);
+    encoded += base64Chars[digit];
   } while (vlq > 0);
 
   return encoded;


### PR DESCRIPTION
## Summary

Replace `base64.encode(digit)` with direct string indexing into a 64-char lookup table in the VLQ encoder hot loop. Avoids a function call and the bounds check inside `base64.encode` for every emitted character.

Touches `lib/base64-vlq.js` only — independent of the `_parseMappings` cluster (#32, #33, #35, #37, #38).

## Bench (jridgewell, two-process)

`scripts/bench-diff.sh main generate` on `preact.js.map`:

| Suite | Op | Δ |
| --- | --- | --- |
| Adding speed | `addMapping` | **+3.7%** |
| Generate speed | `encoded output` | **+6.2%** |

`encoded output` is the targeted metric — it measures `SourceMapGenerator.toString()` which calls `base64VLQ.encode` for every digit. Trace bench is unaffected (consumer never calls `encode`).

## Validation

- `yarn test`: pass (2 pre-existing `# TODO` failures in ECMA-426 conformance, unchanged from `main`).
- `yarn test:coverage`: 98.07 / 97.08 / 96.58 — meets 98 / 97 / 96 thresholds.