### PR TITLE
perf: lazily build originalMappings
  only when accessed

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -80,7 +80,12 @@ Object.defineProperty(SourceMapConsumer.prototype, '_originalMappings', {
   enumerable: true,
   get: function () {
     if (!this.__originalMappings) {
-      this._parseMappings(this._mappings, this.sourceRoot);
+      // Ensure generatedMappings are parsed first (may also set __originalMappings for IndexedSourceMapConsumer)
+      var generatedMappings = this._generatedMappings;
+      // Build originalMappings lazily if not already set (BasicSourceMapConsumer)
+      if (!this.__originalMappings) {
+        this._buildOriginalMappings();
+      }
     }
 
     return this.__originalMappings;
@@ -514,7 +519,6 @@ BasicSourceMapConsumer.prototype._parseMappings =
     var index = 0;
     var cachedSegments = {};
     var temp = {};
-    var originalMappings = [];
     var generatedMappings = [];
     var mapping, str, segment, end, value;
 
@@ -585,21 +589,34 @@ BasicSourceMapConsumer.prototype._parseMappings =
         }
 
         generatedMappings.push(mapping);
-        if (typeof mapping.originalLine === 'number') {
-          let currentSource = mapping.source;
-          while (originalMappings.length <= currentSource) {
-            originalMappings.push(null);
-          }
-          if (originalMappings[currentSource] === null) {
-            originalMappings[currentSource] = [];
-          }
-          originalMappings[currentSource].push(mapping);
-        }
       }
     }
 
     sortGenerated(generatedMappings, subarrayStart);
     this.__generatedMappings = generatedMappings;
+  };
+
+/**
+ * Build originalMappings lazily from generatedMappings.
+ */
+BasicSourceMapConsumer.prototype._buildOriginalMappings =
+  function SourceMapConsumer_buildOriginalMappings() {
+    var generatedMappings = this.__generatedMappings;
+    var originalMappings = [];
+
+    for (var i = 0; i < generatedMappings.length; i++) {
+      var mapping = generatedMappings[i];
+      if (typeof mapping.originalLine === 'number') {
+        var currentSource = mapping.source;
+        while (originalMappings.length <= currentSource) {
+          originalMappings.push(null);
+        }
+        if (originalMappings[currentSource] === null) {
+          originalMappings[currentSource] = [];
+        }
+        originalMappings[currentSource].push(mapping);
+      }
+    }
 
     var nonNullOriginalMappings = [];
     for (var i = 0; i < originalMappings.length; i++) {


### PR DESCRIPTION
## Summary

Move per-source grouping + sort + flatten of `__originalMappings` out of `_parseMappings` and into a new `_buildOriginalMappings`, called lazily by the `_originalMappings` getter. The common `originalPositionFor` path doesn't touch `_originalMappings`, so this skips the work entirely for that workload.

The null-source filter introduced in `6516bdd` is preserved inside `_buildOriginalMappings`.

Touches `lib/source-map-consumer.js` only. Compatible with #36 (skip-sorted-check) and the `_parseMappings` cluster — `_buildOriginalMappings` runs after `_generatedMappings` is materialized.

## Bench (jridgewell, two-process)

`scripts/bench-diff.sh main` on `preact.js.map`:

| Suite | Op | Δ |
| --- | --- | --- |
| **Init speed** | `encoded JSON input` | **+38.2%** |
| **Init speed** | `encoded Object input` | **+53.4%** |
| Trace speed (random) | `encoded originalPositionFor` | +0.6% |
| Trace speed (ascending) | `encoded originalPositionFor` | +1.6% |
| Generated Positions init | `encoded generatedPositionFor` | +1.0% |
| Generated Positions speed | `encoded generatedPositionFor` | +1.7% |
| Adding speed | `addMapping` | +2.4% |
| Generate speed | `encoded output` | +3.3% |

Init benches measure `new Consumer(map).originalPositionFor(...)` — the OPF path no longer needs `_originalMappings`, so per-source quicksort + flatten is skipped entirely. `Generated Positions init` is unchanged because that path still triggers the lazy build.

## Behaviour note (error-timing)

Errors that previously surfaced inside `_parseMappings`'s per-source quicksort now surface on first access of `_originalMappings` (i.e. first `sourceContentFor` / `generatedPositionFor` / `allGeneratedPositionsFor`) instead of first `originalPositionFor`. The set of errors raised, and the values returned for valid input, are unchanged.

## Validation

- `yarn test`: pass (8 pre-existing `# TODO` failures, unchanged from `main`).
- `yarn test:coverage`: 98.08 / 97.08 / 96.61 — meets thresholds.