### PR TITLE
perf: skip sorting when array is already
  sorted

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -479,13 +479,25 @@ function sortGenerated(array, start) {
   let n = array.length - start;
   if (n <= 1) {
     return;
-  } else if (n == 2) {
-    let a = array[start];
-    let b = array[start + 1];
-    if (compareGenerated(a, b) > 0) {
-      array[start] = b;
-      array[start + 1] = a;
+  }
+
+  // Check if already sorted (common case for well-formed source maps)
+  let sorted = true;
+  for (let i = start + 1; i < l; i++) {
+    if (compareGenerated(array[i - 1], array[i]) > 0) {
+      sorted = false;
+      break;
     }
+  }
+  if (sorted) {
+    return;
+  }
+
+  if (n == 2) {
+    // Already checked above, must be out of order
+    let a = array[start];
+    array[start] = array[start + 1];
+    array[start + 1] = a;
   } else if (n < 20) {
     for (let i = start; i < l; i++) {
       for (let j = i; j > start; j--) {

--- a/test/internal/test-source-map-consumer-internals.js
+++ b/test/internal/test-source-map-consumer-internals.js
@@ -18,6 +18,21 @@ var consumerModule = require('../../lib/source-map-consumer');
 var SourceMapConsumer = consumerModule.SourceMapConsumer;
 var BasicSourceMapConsumer = consumerModule.BasicSourceMapConsumer;
 var IndexedSourceMapConsumer = consumerModule.IndexedSourceMapConsumer;
+var base64VLQ = require('../../lib/base64-vlq');
+
+// Build a single-line mappings string from generated-column values.
+// Each segment is just (genColumn delta), so the resulting line has
+// `gens.length` segments whose generated columns are exactly `gens`.
+function makeUnsortedSingleLineMappings(gens) {
+  var out = '';
+  var prev = 0;
+  for (var i = 0; i < gens.length; i++) {
+    if (i > 0) out += ',';
+    out += base64VLQ.encode(gens[i] - prev);
+    prev = gens[i];
+  }
+  return out;
+}
 
 test('test that a BasicSourceMapConsumer is returned for sourcemaps without sections', () => {
   assert.ok(new SourceMapConsumer(util.testMap) instanceof BasicSourceMapConsumer);
@@ -51,4 +66,48 @@ test('IndexedSourceMapConsumer throws on unsupported version', () => {
     version: 2,
     sections: []
   }), /Unsupported version: 2/);
+});
+
+// The internal sortGenerated has three branches based on per-line segment count
+// (n==2, n<20 insertion, n>=20 quicksort) plus an early-exit for already-sorted
+// input. Real-world maps are always sorted, so these tests feed deliberately
+// out-of-order generated columns to exercise the sort branches and the
+// "found out-of-order" path of the pre-scan.
+
+function unsortedSegmentMap(generatedColumns) {
+  return {
+    version: 3,
+    sources: [],
+    names: [],
+    mappings: makeUnsortedSingleLineMappings(generatedColumns)
+  };
+}
+
+function sortedColumns(consumer) {
+  var cols = [];
+  consumer.eachMapping(function (m) { cols.push(m.generatedColumn); });
+  return cols;
+}
+
+test('BasicSourceMapConsumer sorts a 2-segment line whose generated columns are out of order', () => {
+  var map = unsortedSegmentMap([5, 2]);
+  var consumer = new SourceMapConsumer(map);
+  assert.deepStrictEqual(sortedColumns(consumer), [2, 5]);
+});
+
+test('BasicSourceMapConsumer sorts a small line (n<20) whose generated columns are out of order', () => {
+  var unsorted = [10, 2, 7, 1, 9, 3, 8, 4, 6, 5];
+  var map = unsortedSegmentMap(unsorted);
+  var consumer = new SourceMapConsumer(map);
+  assert.deepStrictEqual(sortedColumns(consumer), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+});
+
+test('BasicSourceMapConsumer sorts a large line (n>=20) whose generated columns are out of order', () => {
+  var unsorted = [];
+  for (var i = 30; i >= 1; i--) unsorted.push(i);
+  var map = unsortedSegmentMap(unsorted);
+  var consumer = new SourceMapConsumer(map);
+  var expected = [];
+  for (var j = 1; j <= 30; j++) expected.push(j);
+  assert.deepStrictEqual(sortedColumns(consumer), expected);
 });


### PR DESCRIPTION
## Summary

Add an early-exit pre-scan to the per-line `sortGenerated` so that already-sorted input (i.e. every well-formed source map) skips the sort entirely. Real-world maps are always sorted, so the existing insertion sort / quicksort branches were doing O(n) comparisons per line just to confirm "still sorted."

Touches `lib/source-map-consumer.js` only. The `n == 2` branch is preserved with a fix-up swap (we know it's out of order if we reach it after the pre-scan).

## Bench (jridgewell, two-process)

`scripts/bench-diff.sh main` on `preact.js.map`:

| Suite | Op | Δ |
| --- | --- | --- |
| **Init speed** | `encoded JSON input` | **+29.5%** |
| **Init speed** | `encoded Object input` | **+40.6%** |
| **Generated Positions init** | `encoded generatedPositionFor` | **+37.3%** |
| Trace speed (random) | `encoded originalPositionFor` | −0.4% |
| Trace speed (ascending) | `encoded originalPositionFor` | −1.1% |
| Generated Positions speed | `encoded generatedPositionFor` | −2.3% |
| Adding speed | `addMapping` | +0.9% |
| Generate speed | `encoded output` | −1.6% |

The win is concentrated on parse-time benches (Init / Generated Positions init). Tight-loop benches and generator are unaffected (~within noise).

## Validation

- `yarn test`: pass (8 pre-existing `# TODO` failures, unchanged from `main`).
- `yarn test:coverage`: 98.07 / 97.11 / 96.58 — meets thresholds.
- Without the included test additions, coverage drops to 97.35 / 96.75 — every existing fixture is sorted, so all `sortGenerated` branches go uncovered after the early-exit lands. Added tests in `test/internal/test-source-map-consumer-internals.js` feed deliberately out-of-order generated columns to cover the `n==2` / insertion-sort / quicksort branches and the pre-scan's "out-of-order found" path.