### PR TITLE
perf: add fast path for single-byte
  VLQ decode

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -519,6 +519,21 @@ function sortGenerated(array, start) {
     quickSort(array, compareGenerated, start);
   }
 }
+// Lookup table for single-byte VLQ decode (no continuation bit)
+// Maps base64 char code -> decoded signed value, or undefined if multi-byte
+var vlqTable = [];
+(function() {
+  var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+  for (var i = 0; i < 128; i++) vlqTable[i] = undefined;
+  // Only first 32 base64 values (A-f) are single-byte VLQ (no continuation bit)
+  for (var i = 0; i < 32; i++) {
+    var charCode = chars.charCodeAt(i);
+    // Single-byte VLQ: bit 0 is sign, bits 1-4 are value
+    var value = i >> 1;
+    vlqTable[charCode] = (i & 1) ? -value : value;
+  }
+})();
+
 BasicSourceMapConsumer.prototype._parseMappings =
   function SourceMapConsumer_parseMappings(aStr, aSourceRoot) {
     var generatedLine = 1;
@@ -558,10 +573,17 @@ BasicSourceMapConsumer.prototype._parseMappings =
           if (charCode === 44 || charCode === 59) { // ',' or ';'
             break;
           }
-          base64VLQ.decode(aStr, index, temp);
-          value = temp.value;
-          index = temp.rest;
-          segment.push(value);
+          // Fast path for single-byte VLQ (most common case)
+          value = vlqTable[charCode];
+          if (value !== undefined) {
+            index++;
+            segment.push(value);
+          } else {
+            base64VLQ.decode(aStr, index, temp);
+            value = temp.value;
+            index = temp.rest;
+            segment.push(value);
+          }
         }
 
         if (segment.length === 2) {


### PR DESCRIPTION
## Summary

Add a 32-entry lookup table mapping each single-byte VLQ char (covering signed values −15..15, the most common case in real source maps) to its decoded value. The `_parseMappings` inner segment-decode loop checks the table first; only multi-byte VLQs fall through to `base64VLQ.decode`. Skips the function call + `temp` object write for the common case.

Touches `lib/source-map-consumer.js` only.

## Conflicts

Per pr-stack-review.md, conflicts with #32 / #33 / #38 — all rewrite the inner segment-decode loop. Whichever lands first wins; the rest need rebases.

## Bench (jridgewell, two-process)

`scripts/bench-diff.sh main` on `preact.js.map`:

| Suite | Op | Δ |
| --- | --- | --- |
| Init speed | `encoded JSON input` | **+5.4%** |
| Init speed | `encoded Object input` | **+7.4%** |
| Trace speed (random) | `encoded originalPositionFor` | +1.6% |
| Trace speed (ascending) | `encoded originalPositionFor` | +1.9% |
| Generated Positions init | `encoded generatedPositionFor` | **+8.2%** |
| Generated Positions speed | `encoded generatedPositionFor` | −0.5% |
| Adding speed | `addMapping` | −0.9% |
| Generate speed | `encoded output` | −1.5% |

Mean +2.69%. Win is concentrated on parse-time benches; tight-loop trace and generator side are within noise.

## Validation

- `yarn test`: pass (8 pre-existing `# TODO` failures, unchanged from `main`).
- `yarn test:coverage`: 98.08 / 97.12 / 96.61 — meets thresholds.