### PR TITLE
perf: remove end-finding loop in
  VLQ decode

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -531,7 +531,7 @@ BasicSourceMapConsumer.prototype._parseMappings =
     var index = 0;
     var temp = {};
     var generatedMappings = [];
-    var mapping, segment, end, value, charCode;
+    var mapping, segment, value, charCode;
 
     let subarrayStart = 0;
     while (index < length) {
@@ -551,16 +551,13 @@ BasicSourceMapConsumer.prototype._parseMappings =
         mapping = new Mapping();
         mapping.generatedLine = generatedLine;
 
-        // Find end of segment (next ';' or ',')
-        for (end = index; end < length; end++) {
-          charCode = aStr.charCodeAt(end);
+        // Decode VLQ values until we hit a separator
+        segment = [];
+        while (index < length) {
+          charCode = aStr.charCodeAt(index);
           if (charCode === 44 || charCode === 59) { // ',' or ';'
             break;
           }
-        }
-
-        segment = [];
-        while (index < end) {
           base64VLQ.decode(aStr, index, temp);
           value = temp.value;
           index = temp.rest;


### PR DESCRIPTION
## Summary

Drop the per-segment "find end" pre-scan in `_parseMappings`. Instead, check for `,` / `;` at the start of each VLQ-decode iteration and break out when hit. Eliminates one full O(n) scan per segment.

Touches `lib/source-map-consumer.js` only.

## Conflicts with #32

Both this PR and #32 rewrite the inner segment-decode loop. #32 keeps the pre-scan but inlines the `charCodeAt` check; this PR removes the pre-scan entirely. Whichever lands first wins; the loser needs a one-shot rebase.

## Bench (jridgewell, two-process)

`scripts/bench-diff.sh main`:

### preact.js.map (1992 segments) — bench-noise dominated

| Suite | Op | Δ |
| --- | --- | --- |
| Init speed | `encoded JSON input` | +0.6% |
| Init speed | `encoded Object input` | +2.4% |
| Trace speed (random) | `encoded originalPositionFor` | −2.6% |
| Trace speed (ascending) | `encoded originalPositionFor` | −2.9% |
| Generated Positions init | `encoded generatedPositionFor` | +3.4% |
| Generated Positions speed | `encoded generatedPositionFor` | +0.4% |
| Adding speed | `addMapping` | −3.0% |
| Generate speed | `encoded output` | −1.4% |

Mean −0.4%. preact is small enough that bench variance dominates.

### babel.min.js.map (347793 segments) — real signal

| Suite | Op | Δ |
| --- | --- | --- |
| Init speed | `encoded JSON input` | **+6.8%** |
| Init speed | `encoded Object input` | **+4.5%** |
| Trace speed (random) | `encoded originalPositionFor` | **+6.6%** |
| Trace speed (ascending) | `encoded originalPositionFor` | **+5.6%** |
| Generated Positions init | `encoded generatedPositionFor` | **+10.4%** |
| Generated Positions speed | `encoded generatedPositionFor` | +5.9% |
| Adding speed | `addMapping` | −2.3% |
| Generate speed | `encoded output` | +1.6% |

Mean +4.89%. Win is consistent across parse-side benches; generator side is unaffected as expected.

## Validation

- `yarn test`: pass (8 pre-existing `# TODO` failures, unchanged from `main`).
- `yarn test:coverage`: 98.07 / 97.09 / 96.58 — meets thresholds.