### PR TITLE
perf: use object literal instead of
  Mapping constructor

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -566,8 +566,14 @@ BasicSourceMapConsumer.prototype._parseMappings =
         index++;
       }
       else {
-        mapping = new Mapping();
-        mapping.generatedLine = generatedLine;
+        mapping = {
+          generatedLine: generatedLine,
+          generatedColumn: 0,
+          source: null,
+          originalLine: null,
+          originalColumn: null,
+          name: null
+        };
 
         // Decode VLQ values until we hit a separator
         segmentLength = 0;


### PR DESCRIPTION
## Summary

Replace `new Mapping()` + property assignments with an object literal in `_parseMappings`. Sets all six fields up front in the same order as the `Mapping` constructor, so V8 should produce the same hidden class shape for the same access pattern, but the literal avoids the constructor-call overhead.

`Mapping` constructor is preserved on the prototype; `applySourceMap` still uses `new Mapping`.

Touches `lib/source-map-consumer.js` only.

## Bench (jridgewell, two-process)

`scripts/bench-diff.sh main`:

### preact.js.map (1992 segments) — too small to see the win

| Suite | Op | Δ |
| --- | --- | --- |
| Init speed | `encoded JSON input` | +1.1% |
| Init speed | `encoded Object input` | +0.8% |
| Trace speed (random) | `encoded originalPositionFor` | −0.5% |
| Trace speed (ascending) | `encoded originalPositionFor` | +1.4% |
| Generated Positions init | `encoded generatedPositionFor` | −0.9% |
| Generated Positions speed | `encoded generatedPositionFor` | −0.3% |
| Adding speed | `addMapping` | +2.0% |
| Generate speed | `encoded output` | −0.5% |

Mean +0.37% — within noise.

### babel.min.js.map (347793 segments) — the real signal

| Suite | Op | Δ |
| --- | --- | --- |
| Init speed | `encoded JSON input` | **+39.1%** |
| Init speed | `encoded Object input` | **+53.8%** |
| Trace speed (random) | `encoded originalPositionFor` | +0.3% |
| Trace speed (ascending) | `encoded originalPositionFor` | +2.3% |
| Generated Positions init | `encoded generatedPositionFor` | **+46.6%** |
| Generated Positions speed | `encoded generatedPositionFor` | +2.9% |

Mean +24.15% (trace-only suite). The win scales with mapping count — at ~350k mappings the per-mapping allocation overhead dominates; preact's 2k is too few to see it.

## Concern (per pr-stack-review)

The `Mapping` ctor docblock says: *"Provide the JIT with a nice shape / hidden class."* `applySourceMap` still uses `new Mapping`, so a consumer that goes through `applySourceMap` ends up with a mix of literal-created and ctor-created mappings — different hidden classes, polymorphic callsites in `eachMapping` etc.

For the regular `new SourceMapConsumer(map)` flow, there is only one shape (the literal's), so nothing is mixed. Worth landing for the bench win, but flagging in case `applySourceMap`-heavy users see a regression.

## Validation

- `yarn test`: pass (8 pre-existing `# TODO` failures, unchanged from `main`).
- `yarn test:coverage`: 98.07 / 97.08 / 96.58 — meets thresholds.