### PR TITLE
perf: add fast path for single-char
  VLQ encode

### DIFF
--- a/lib/source-map-generator.js
+++ b/lib/source-map-generator.js
@@ -323,6 +323,17 @@ SourceMapGenerator.prototype._validateMapping =
     }
   };
 
+// Fast VLQ encode lookup for values -15 to 15 (single char output)
+var vlqEncodeTable = [];
+(function() {
+  var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+  for (var i = -15; i <= 15; i++) {
+    // VLQ signed: negative becomes odd, positive becomes even
+    var vlq = i < 0 ? ((-i) << 1) + 1 : (i << 1);
+    vlqEncodeTable[i + 15] = chars[vlq];
+  }
+})();
+
 /**
  * Serialize the accumulated mappings in to the stream of base 64 VLQs
  * specified by the source map format.
@@ -336,7 +347,7 @@ SourceMapGenerator.prototype._serializeMappings =
     var previousName = 0;
     var previousSource = 0;
     var result = '';
-    var next;
+    var next, val;
     var mapping;
     var nameIdx;
     var sourceIdx;
@@ -362,27 +373,29 @@ SourceMapGenerator.prototype._serializeMappings =
         }
       }
 
-      next += base64VLQ.encode(mapping.generatedColumn
-                                 - previousGeneratedColumn);
+      val = mapping.generatedColumn - previousGeneratedColumn;
+      next += (val >= -15 && val <= 15) ? vlqEncodeTable[val + 15] : base64VLQ.encode(val);
       previousGeneratedColumn = mapping.generatedColumn;
 
       if (mapping.source != null) {
         sourceIdx = this._sources.indexOf(mapping.source);
-        next += base64VLQ.encode(sourceIdx - previousSource);
+        val = sourceIdx - previousSource;
+        next += (val >= -15 && val <= 15) ? vlqEncodeTable[val + 15] : base64VLQ.encode(val);
         previousSource = sourceIdx;
 
         // lines are stored 0-based in SourceMap spec version 3
-        next += base64VLQ.encode(mapping.originalLine - 1
-                                   - previousOriginalLine);
+        val = mapping.originalLine - 1 - previousOriginalLine;
+        next += (val >= -15 && val <= 15) ? vlqEncodeTable[val + 15] : base64VLQ.encode(val);
         previousOriginalLine = mapping.originalLine - 1;
 
-        next += base64VLQ.encode(mapping.originalColumn
-                                   - previousOriginalColumn);
+        val = mapping.originalColumn - previousOriginalColumn;
+        next += (val >= -15 && val <= 15) ? vlqEncodeTable[val + 15] : base64VLQ.encode(val);
         previousOriginalColumn = mapping.originalColumn;
 
         if (mapping.name != null) {
           nameIdx = this._names.indexOf(mapping.name);
-          next += base64VLQ.encode(nameIdx - previousName);
+          val = nameIdx - previousName;
+          next += (val >= -15 && val <= 15) ? vlqEncodeTable[val + 15] : base64VLQ.encode(val);
           previousName = nameIdx;
         }
       }


### PR DESCRIPTION
## Summary

Add a precomputed lookup table for the most common case in VLQ encoding: deltas in `[-15, 15]` encode to a single base64 char. Inline that lookup at the five `_serializeMappings` callsites; only fall through to `base64VLQ.encode` for larger deltas.

Touches `lib/source-map-generator.js` only. Independent of `lib/base64-vlq.js` work (#34) — the two compose: #40 catches small deltas inline, #34 makes the `base64VLQ.encode` fallback faster.

## Bench (jridgewell, two-process)

`scripts/bench-diff.sh main generate` on `preact.js.map`:

| Suite | Op | Δ |
| --- | --- | --- |
| Adding speed | `addMapping` | −0.1% |
| Generate speed | `encoded output` | **+12.0%** |

`encoded output` is the targeted hot path (`SourceMapGenerator.toString` → `_serializeMappings`). `addMapping` is unaffected as expected — that path doesn't run VLQ encoding.

## Validation

- `yarn test`: pass (8 pre-existing `# TODO` failures, unchanged from `main`).
- `yarn test:coverage`: 98.08 / 97.17 / 96.61 — meets 98 / 97 / 96 thresholds.