### PR TITLE
perf: convert recursive binary search to iterative

### DIFF
--- a/lib/binary-search.js
+++ b/lib/binary-search.js
@@ -9,7 +9,7 @@ exports.GREATEST_LOWER_BOUND = 1;
 exports.LEAST_UPPER_BOUND = 2;
 
 /**
- * Recursive implementation of binary search.
+ * Iterative implementation of binary search.
  *
  * @param aLow Indices here and lower do not contain the needle.
  * @param aHigh Indices here and higher do not contain the needle.
@@ -21,7 +21,7 @@ exports.LEAST_UPPER_BOUND = 2;
  *     closest element that is smaller than or greater than the one we are
  *     searching for, respectively, if the exact element cannot be found.
  */
-function recursiveSearch(aLow, aHigh, aNeedle, aHaystack, aCompare, aBias) {
+function iterativeSearch(aLow, aHigh, aNeedle, aHaystack, aCompare, aBias) {
   // This function terminates when one of the following is true:
   //
   //   1. We find the exact element we are looking for.
@@ -31,39 +31,43 @@ function recursiveSearch(aLow, aHigh, aNeedle, aHaystack, aCompare, aBias) {
   //
   //   3. We did not find the exact element, and there is no next-closest
   //      element than the one we are searching for, so we return -1.
-  var mid = Math.floor((aHigh - aLow) / 2) + aLow;
-  var cmp = aCompare(aNeedle, aHaystack[mid], true);
-  if (cmp === 0) {
-    // Found the element we are looking for.
-    return mid;
-  }
-  else if (cmp > 0) {
-    // Our needle is greater than aHaystack[mid].
-    if (aHigh - mid > 1) {
-      // The element is in the upper half.
-      return recursiveSearch(mid, aHigh, aNeedle, aHaystack, aCompare, aBias);
-    }
-
-    // The exact needle element was not found in this haystack. Determine if
-    // we are in termination case (3) or (2) and return the appropriate thing.
-    if (aBias == exports.LEAST_UPPER_BOUND) {
-      return aHigh < aHaystack.length ? aHigh : -1;
-    } else {
+  while (true) {
+    var mid = Math.floor((aHigh - aLow) / 2) + aLow;
+    var cmp = aCompare(aNeedle, aHaystack[mid], true);
+    if (cmp === 0) {
+      // Found the element we are looking for.
       return mid;
     }
-  }
-  else {
-    // Our needle is less than aHaystack[mid].
-    if (mid - aLow > 1) {
-      // The element is in the lower half.
-      return recursiveSearch(aLow, mid, aNeedle, aHaystack, aCompare, aBias);
-    }
+    else if (cmp > 0) {
+      // Our needle is greater than aHaystack[mid].
+      if (aHigh - mid > 1) {
+        // The element is in the upper half.
+        aLow = mid;
+        continue;
+      }
 
-    // we are in termination case (3) or (2) and return the appropriate thing.
-    if (aBias == exports.LEAST_UPPER_BOUND) {
-      return mid;
-    } else {
-      return aLow < 0 ? -1 : aLow;
+      // The exact needle element was not found in this haystack. Determine if
+      // we are in termination case (3) or (2) and return the appropriate thing.
+      if (aBias == exports.LEAST_UPPER_BOUND) {
+        return aHigh < aHaystack.length ? aHigh : -1;
+      } else {
+        return mid;
+      }
+    }
+    else {
+      // Our needle is less than aHaystack[mid].
+      if (mid - aLow > 1) {
+        // The element is in the lower half.
+        aHigh = mid;
+        continue;
+      }
+
+      // we are in termination case (3) or (2) and return the appropriate thing.
+      if (aBias == exports.LEAST_UPPER_BOUND) {
+        return mid;
+      } else {
+        return aLow < 0 ? -1 : aLow;
+      }
     }
   }
 }
@@ -91,7 +95,7 @@ exports.search = function search(aNeedle, aHaystack, aCompare, aBias) {
     return -1;
   }
 
-  var index = recursiveSearch(-1, aHaystack.length, aNeedle, aHaystack,
+  var index = iterativeSearch(-1, aHaystack.length, aNeedle, aHaystack,
                               aCompare, aBias || exports.GREATEST_LOWER_BOUND);
   if (index < 0) {
     return -1;


### PR DESCRIPTION
## Summary

Convert `recursiveSearch` in `lib/binary-search.js` to a `while`-loop iteration, mutating `aLow` / `aHigh` in place rather than recursing. Saves a stack frame per probe in the hot lookup path used by every `originalPositionFor` / `generatedPositionFor` / `allGeneratedPositionsFor` call, and removes a deep-stack risk on very large maps (`bench-trace.txt` shows a 9-deep `recursiveSearch` stack on the vscode.map crash; on a 2M-segment map the recursion is ~21 deep).

Touches `lib/binary-search.js` only. Function renamed `recursiveSearch` → `iterativeSearch` to match the new behavior; the function is internal (only called from `binarySearch.search`), so the rename is local-only.

## Bench (jridgewell, two-process, full fixtures)

`scripts/bench-diff.sh main`. Wins concentrated on the binary-search-touching paths (trace + generated-position speed). Init-side measurements don't go through binary search and show two-process bench-rig noise.

| Fixture | Trace random | Trace ascending | GenPos speed |
| --- | --- | --- | --- |
| amp.js.map | −4.3% | +2.7% | **+5.2%** |
| babel.min.js.map | **+6.9%** | **+13.9%** | **+18.0%** |
| issue-41.js.map | **+11.9%** | **+11.8%** | **+10.7%** |
| preact.js.map | **+8.6%** | **+9.2%** | **+14.5%** |
| react.js.map | **+13.0%** | **+10.1%** | **+14.5%** |
| vscode.map | **+10.8%** | **+12.1%** | **+17.1%** |

48 rows compared, mean +3.23% (dragged down by init/generate rows that don't exercise binary search).

The pattern matches the projected ~10–15% from `bench-jridgewell-analysis.md` lever 6 (iterative search). The win scales with mapping count — preact (~2k mappings, depth ~11) sits in the ~9–14% range; babel.min (~350k, depth ~18) and react (~7k, depth ~13) hit ~14–18% on the lookup-heavy bench.

## Validation

- `yarn test`: 177 pass, 0 fail, 8 pre-existing `# TODO` (unchanged from main).
- `yarn test:coverage`: 98.11 / 97.24 / 96.67 — meets 98 / 97 / 96 thresholds.