### PR TITLE
perf: use Uint8Array LUT for base64 decode

### DIFF
--- a/lib/base64-vlq.js
+++ b/lib/base64-vlq.js
@@ -40,6 +40,9 @@ var base64 = require('./base64');
 // Inlined base64 encode lookup for performance (avoids function call + bounds check)
 var base64Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
 
+// Inlined base64 decode lookup; 255 sentinel marks invalid chars.
+var base64Decode = base64.charToIntMap;
+
 // A single base 64 digit can contain 6 bits of data. For the base 64 variable
 // length quantities we use in the source map spec, the first bit is the sign,
 // the next four bits are the actual value, and the 6th bit is the
@@ -120,15 +123,16 @@ exports.decode = function base64VLQ_decode(aStr, aIndex, aOutParam) {
   var strLen = aStr.length;
   var result = 0;
   var shift = 0;
-  var continuation, digit;
+  var continuation, digit, charCode;
 
   do {
     if (aIndex >= strLen) {
       throw new Error("Expected more digits in base 64 VLQ value.");
     }
 
-    digit = base64.decode(aStr.charCodeAt(aIndex++));
-    if (digit === -1) {
+    charCode = aStr.charCodeAt(aIndex++);
+    digit = charCode < 128 ? base64Decode[charCode] : 255;
+    if (digit === 255) {
       throw new Error("Invalid base64 digit: " + aStr.charAt(aIndex - 1));
     }
 

--- a/lib/base64.js
+++ b/lib/base64.js
@@ -7,6 +7,15 @@
 
 var intToCharMap = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'.split('');
 
+// Lookup table: base64 char code -> 6-bit value. Invalid chars hold 255 as a sentinel.
+// Exported so the VLQ decoder can index it directly without a function call.
+var charToIntMap = new Uint8Array(128);
+charToIntMap.fill(255);
+for (var i = 0; i < 64; i++) {
+  charToIntMap[intToCharMap[i].charCodeAt(0)] = i;
+}
+exports.charToIntMap = charToIntMap;
+
 /**
  * Encode an integer in the range of 0 to 63 to a single base 64 digit.
  */
@@ -22,46 +31,11 @@ exports.encode = function (number) {
  * failure.
  */
 exports.decode = function (charCode) {
-  var bigA = 65;     // 'A'
-  var bigZ = 90;     // 'Z'
-
-  var littleA = 97;  // 'a'
-  var littleZ = 122; // 'z'
-
-  var zero = 48;     // '0'
-  var nine = 57;     // '9'
-
-  var plus = 43;     // '+'
-  var slash = 47;    // '/'
-
-  var littleOffset = 26;
-  var numberOffset = 52;
-
-  // 0 - 25: ABCDEFGHIJKLMNOPQRSTUVWXYZ
-  if (bigA <= charCode && charCode <= bigZ) {
-    return (charCode - bigA);
+  if (charCode >= 0 && charCode < 128) {
+    var v = charToIntMap[charCode];
+    if (v !== 255) {
+      return v;
+    }
   }
-
-  // 26 - 51: abcdefghijklmnopqrstuvwxyz
-  if (littleA <= charCode && charCode <= littleZ) {
-    return (charCode - littleA + littleOffset);
-  }
-
-  // 52 - 61: 0123456789
-  if (zero <= charCode && charCode <= nine) {
-    return (charCode - zero + numberOffset);
-  }
-
-  // 62: +
-  if (charCode == plus) {
-    return 62;
-  }
-
-  // 63: /
-  if (charCode == slash) {
-    return 63;
-  }
-
-  // Invalid base64 digit.
   return -1;
 };


### PR DESCRIPTION
## Summary

Replace the 7-branch range-check ladder in `base64.decode` with a 128-entry `Uint8Array` indexed by char code (255 sentinel for invalid characters). Export the table from `lib/base64.js` so the VLQ decoder in `lib/base64-vlq.js` can index it directly, removing the `base64.decode` function-call boundary inside the multi-byte VLQ inner loop.

This is `bench-jridgewell-analysis.md` lever 5 (`Uint8Array` lookup table) — projected 2–3× on the VLQ hot path. The win is concentrated on the *multi-byte* VLQ path; single-byte VLQs (the most common case for small deltas) are already short-circuited by the existing `vlqTable` fast-path in `lib/source-map-consumer.js`. So the wins scale with the proportion of multi-byte VLQs in a map, which scales with the size of column / source / line deltas.

Touches `lib/base64.js` and `lib/base64-vlq.js` only.

## Bench (jridgewell, two-process, full fixtures)

`scripts/bench-diff.sh main`. Wins concentrated on init-side benches (which exercise `_parseMappings` → `base64VLQ.decode` for every multi-byte VLQ).

| Fixture | Init JSON | Init Object | GenPos init |
| --- | --- | --- | --- |
| amp.js.map | **+4.3%** | **+4.4%** | **+3.4%** |
| babel.min.js.map | **+8.0%** | **+11.6%** | +0.0% |
| issue-41.js.map | +2.1% | +0.0% | +0.5% |
| preact.js.map | −3.6% | −8.0% | −0.6% |
| react.js.map | −2.0% | −4.0% | +0.5% |
| vscode.map | **+5.6%** | **+6.0%** | **+4.4%** |

The preact/react init regressions match the two-process bench-rig noise pattern seen in #45 (where binary-search changes that *can't* affect init showed −2.9% / −6.9% on the same fixtures). preact has the smallest deltas of the fixtures, so the multi-byte VLQ path runs least — the LUT change has the smallest opportunity to win there, leaving the bench-rig variance to dominate. The signal we care about — large maps with many multi-byte VLQs (babel.min, vscode, amp) — shows consistent +4 to +12% wins on init.

48 rows compared, mean +0.51%. The mean is dragged down by trace/generate rows that don't run through `base64VLQ.decode` at all.

## Conflicts

Independent of #45 (binary-search). Touches different files than the parse-mappings cluster.

## Validation

- `yarn test`: 177 pass, 0 fail, 8 pre-existing \`# TODO\` (unchanged from main).
- `yarn test:coverage`: 98.10 / 97.02 / 96.67 — meets 98 / 97 / 96 thresholds.