### PR TITLE
chore(bench): add SOLO and PHASES env filters to jridgewell bench

### DIFF
--- a/benchmarks/jridgewell/generate.mjs
+++ b/benchmarks/jridgewell/generate.mjs
@@ -20,7 +20,16 @@ import { SourceMapGenerator as SourceMapGeneratorWasm } from 'source-map-wasm';
 const { SourceMapGenerator: CurrentSourceMapGenerator } = currentSourceMap;
 
 const dir = relative(process.cwd(), join(dirname(fileURLToPath(import.meta.url)), 'fixtures'));
-const { DIFF, FILE } = process.env;
+const { DIFF, FILE, SOLO, PHASES } = process.env;
+
+// SOLO=1: only benchmark `source-map-js current` (skip every third-party
+// case). bench-delta.js only diffs that label across two runs.
+//
+// PHASES=key1,key2: only run the named Benchmark.Suite phases. Keys:
+//   adding, generate
+// Default (unset) runs all phases.
+const phasesSet = PHASES ? new Set(PHASES.split(',').map((s) => s.trim())) : null;
+const phaseEnabled = (key) => !phasesSet || phasesSet.has(key);
 
 console.log(`node ${process.version}\n`);
 
@@ -110,7 +119,9 @@ async function bench(file) {
   });
 
   let genmap, smgjsLatest, smg061, smgWasm;
-  if (DIFF) {
+  if (SOLO) {
+    // skip all comparison libraries
+  } else if (DIFF) {
     smgjsLatest = track('source-map-js latest', results, () => {
       return buildSourceMapJsGenerator(SourceMapGeneratorJsLatest, mappings, sources, names);
     });
@@ -172,11 +183,14 @@ async function bench(file) {
 
   console.log('');
 
+  if (phaseEnabled('adding')) {
   console.log('Adding speed:');
   let suite = new Benchmark.Suite().add('source-map-js current: addMapping', () => {
     buildSourceMapJsGenerator(CurrentSourceMapGenerator, mappings, sources, names);
   });
-  if (DIFF) {
+  if (SOLO) {
+    // only source-map-js current
+  } else if (DIFF) {
     suite = suite.add('source-map-js latest:  addMapping', () => {
       buildSourceMapJsGenerator(SourceMapGeneratorJsLatest, mappings, sources, names);
     });
@@ -239,12 +253,16 @@ async function bench(file) {
     .run({});
 
   console.log('');
+  }
 
+  if (phaseEnabled('generate')) {
   console.log('Generate speed:');
   let genSuite = new Benchmark.Suite().add('source-map-js current: encoded output', () => {
     smgjsCurrent.toJSON();
   });
-  if (DIFF) {
+  if (SOLO) {
+    // only source-map-js current
+  } else if (DIFF) {
     genSuite = genSuite.add('source-map-js latest:  encoded output', () => {
       smgjsLatest.toJSON();
     });
@@ -272,6 +290,7 @@ async function bench(file) {
       console.log('Fastest is ' + this.filter('fastest').map('name'));
     })
     .run({});
+  }
 }
 
 async function run(files) {

--- a/benchmarks/jridgewell/trace.mjs
+++ b/benchmarks/jridgewell/trace.mjs
@@ -20,7 +20,17 @@ import { SourceMap as ChromeMap2026 } from './chrome-2026.mjs';
 const { SourceMapConsumer: CurrentSourceMapConsumer } = currentSourceMap;
 
 const dir = relative(process.cwd(), join(dirname(fileURLToPath(import.meta.url)), 'fixtures'));
-const { DIFF, FILE } = process.env;
+const { DIFF, FILE, SOLO, PHASES } = process.env;
+
+// SOLO=1: only benchmark `source-map-js current` (skip every third-party
+// case). bench-delta.js only diffs that label across two runs, so the rest is
+// pure runtime tax for bench-diff.sh.
+//
+// PHASES=key1,key2: only run the named Benchmark.Suite phases. Keys:
+//   init, trace-random, trace-ascending, genpos-init, genpos-speed
+// Default (unset) runs all phases.
+const phasesSet = PHASES ? new Set(PHASES.split(',').map((s) => s.trim())) : null;
+const phaseEnabled = (key) => !phasesSet || phasesSet.has(key);
 
 console.log(`node ${process.version}\n`);
 
@@ -73,7 +83,9 @@ async function bench(file) {
   const firstSource = smcjsCurrent.sources[0];
   smcjsCurrent.generatedPositionFor({ source: firstSource, line: 1, column: 0 });
 
-  if (DIFF) {
+  if (SOLO) {
+    // skip all comparison libraries
+  } else if (DIFF) {
     smcjsLatest = await track('source-map-js latest', results, () => {
       const smc = new SourceMapConsumerJsLatest(encodedMapData);
       smc.originalPositionFor({ line: 1, column: 0 });
@@ -123,60 +135,65 @@ async function bench(file) {
 
   console.log('');
 
-  console.log('Init speed:');
-  benchmark = new Benchmark.Suite()
-    .add('source-map-js current: encoded JSON input', () => {
-      new CurrentSourceMapConsumer(encodedMapDataJson).originalPositionFor({ line: 1, column: 0 });
-    })
-    .add('source-map-js current: encoded Object input', () => {
-      new CurrentSourceMapConsumer(encodedMapData).originalPositionFor({ line: 1, column: 0 });
-    });
-  if (DIFF) {
-    benchmark = benchmark
-      .add('source-map-js latest:  encoded JSON input', () => {
-        new SourceMapConsumerJsLatest(encodedMapDataJson).originalPositionFor({ line: 1, column: 0 });
+  if (phaseEnabled('init')) {
+    console.log('Init speed:');
+    benchmark = new Benchmark.Suite()
+      .add('source-map-js current: encoded JSON input', () => {
+        new CurrentSourceMapConsumer(encodedMapDataJson).originalPositionFor({ line: 1, column: 0 });
       })
-      .add('source-map-js latest:  encoded Object input', () => {
-        new SourceMapConsumerJsLatest(encodedMapData).originalPositionFor({ line: 1, column: 0 });
+      .add('source-map-js current: encoded Object input', () => {
+        new CurrentSourceMapConsumer(encodedMapData).originalPositionFor({ line: 1, column: 0 });
       });
-  } else {
-    benchmark = benchmark
-      .add('trace-mapping:    decoded JSON input', () => {
-        traceSegment(new TraceMap(decodedMapDataJson), 0, 0);
+    if (SOLO) {
+      // only source-map-js current
+    } else if (DIFF) {
+      benchmark = benchmark
+        .add('source-map-js latest:  encoded JSON input', () => {
+          new SourceMapConsumerJsLatest(encodedMapDataJson).originalPositionFor({ line: 1, column: 0 });
+        })
+        .add('source-map-js latest:  encoded Object input', () => {
+          new SourceMapConsumerJsLatest(encodedMapData).originalPositionFor({ line: 1, column: 0 });
+        });
+    } else {
+      benchmark = benchmark
+        .add('trace-mapping:    decoded JSON input', () => {
+          traceSegment(new TraceMap(decodedMapDataJson), 0, 0);
+        })
+        .add('trace-mapping:    encoded JSON input', () => {
+          traceSegment(new TraceMap(encodedMapDataJson), 0, 0);
+        })
+        .add('trace-mapping:    decoded Object input', () => {
+          traceSegment(new TraceMap(decodedMapData), 0, 0);
+        })
+        .add('trace-mapping:    encoded Object input', () => {
+          traceSegment(new TraceMap(encodedMapData), 0, 0);
+        })
+        .add('source-map-0.6.1: encoded Object input', () => {
+          new SourceMapConsumer061(encodedMapData).originalPositionFor({ line: 1, column: 0 });
+        })
+        .add('Chrome dev tools: encoded Object input', () => {
+          new ChromeMap('url', encodedMapData).findEntry(0, 0);
+        })
+        .add('Chrome dev tools 2026: encoded Object input', () => {
+          new ChromeMap2026('url', encodedMapData).findEntry(0, 0);
+        });
+      // WASM isn't tested in init because its async and OOMs.
+      // .add('source-map-0.8.0: encoded Object input', () => { })
+    }
+    benchmark
+      .on('error', (event) => console.error(event.target.error))
+      .on('cycle', (event) => {
+        console.log(String(event.target));
       })
-      .add('trace-mapping:    encoded JSON input', () => {
-        traceSegment(new TraceMap(encodedMapDataJson), 0, 0);
+      .on('complete', function () {
+        console.log('Fastest is ' + this.filter('fastest').map('name'));
       })
-      .add('trace-mapping:    decoded Object input', () => {
-        traceSegment(new TraceMap(decodedMapData), 0, 0);
-      })
-      .add('trace-mapping:    encoded Object input', () => {
-        traceSegment(new TraceMap(encodedMapData), 0, 0);
-      })
-      .add('source-map-0.6.1: encoded Object input', () => {
-        new SourceMapConsumer061(encodedMapData).originalPositionFor({ line: 1, column: 0 });
-      })
-      .add('Chrome dev tools: encoded Object input', () => {
-        new ChromeMap('url', encodedMapData).findEntry(0, 0);
-      })
-      .add('Chrome dev tools 2026: encoded Object input', () => {
-        new ChromeMap2026('url', encodedMapData).findEntry(0, 0);
-      });
-    // WASM isn't tested in init because its async and OOMs.
-    // .add('source-map-0.8.0: encoded Object input', () => { })
+      .run({});
+
+    console.log('');
   }
-  benchmark
-    .on('error', (event) => console.error(event.target.error))
-    .on('cycle', (event) => {
-      console.log(String(event.target));
-    })
-    .on('complete', function () {
-      console.log('Fastest is ' + this.filter('fastest').map('name'));
-    })
-    .run({});
 
-  console.log('');
-
+  if (phaseEnabled('trace-random')) {
   console.log('Trace speed (random):');
   benchmark = new Benchmark.Suite()
     .add('source-map-js current: encoded originalPositionFor', () => {
@@ -190,7 +207,9 @@ async function bench(file) {
         smcjsCurrent.originalPositionFor({ line: i + 1, column });
       }
     });
-  if (DIFF) {
+  if (SOLO) {
+    // only source-map-js current
+  } else if (DIFF) {
     benchmark = benchmark.add('source-map-js latest: encoded originalPositionFor', () => {
       const i = Math.floor(Math.random() * lines.length);
       const line = lines[i];
@@ -271,7 +290,9 @@ async function bench(file) {
     .run({});
 
   console.log('');
+  }
 
+  if (phaseEnabled('trace-ascending')) {
   console.log('Trace speed (ascending):');
   benchmark = new Benchmark.Suite()
     .add('source-map-js current: encoded originalPositionFor', () => {
@@ -284,7 +305,9 @@ async function bench(file) {
         smcjsCurrent.originalPositionFor({ line: i + 1, column });
       }
     });
-  if (DIFF) {
+  if (SOLO) {
+    // only source-map-js current
+  } else if (DIFF) {
     benchmark = benchmark.add('source-map-js latest: encoded originalPositionFor', () => {
       const i = Math.floor(Math.random() * lines.length);
       const line = lines[i];
@@ -359,14 +382,18 @@ async function bench(file) {
     .run({});
 
   console.log('');
+  }
 
+  if (phaseEnabled('genpos-init')) {
   console.log('Generated Positions init:');
   benchmark = new Benchmark.Suite()
     .add('source-map-js current: encoded generatedPositionFor', () => {
       const smc = new CurrentSourceMapConsumer(encodedMapData);
       smc.generatedPositionFor({ source: firstSource, line: 6, column: 0 });
     });
-  if (DIFF) {
+  if (SOLO) {
+    // only source-map-js current
+  } else if (DIFF) {
     benchmark = benchmark.add('source-map-js latest: encoded generatedPositionFor', () => {
       const smc = new SourceMapConsumerJsLatest(encodedMapData);
       smc.generatedPositionFor({ source: firstSource, line: 6, column: 0 });
@@ -407,7 +434,9 @@ async function bench(file) {
     .run({});
 
   console.log('');
+  }
 
+  if (phaseEnabled('genpos-speed')) {
   console.log('Generated Positions speed:');
   benchmark = new Benchmark.Suite()
     .add('source-map-js current: encoded generatedPositionFor', () => {
@@ -415,7 +444,9 @@ async function bench(file) {
         smcjsCurrent.generatedPositionFor({ source, line: 6, column: 0 });
       }
     });
-  if (DIFF) {
+  if (SOLO) {
+    // only source-map-js current
+  } else if (DIFF) {
     benchmark = benchmark.add('source-map-js latest: encoded generatedPositionFor', () => {
       for (const source of smcjsLatest.sources) {
         smcjsLatest.generatedPositionFor({ source, line: 6, column: 0 });
@@ -458,6 +489,7 @@ async function bench(file) {
       console.log('Fastest is ' + this.filter('fastest').map('name'));
     })
     .run({});
+  }
 
   if (smcWasm) smcWasm.destroy();
 }


### PR DESCRIPTION
## Summary

`scripts/bench-diff.sh` runs the jridgewell bench rig in two processes (candidate and baseline) and `bench-delta.js` only diffs the `source-map-js current` rows across them. Every other library's ops/sec line — `trace-mapping`, `source-map-0.6.1`, `source-map-0.8.0`, Chrome dev tools, Chrome dev tools 2026, even `source-map-js latest` — is pure runtime tax in that workflow.

Most perf changes also touch one phase only (e.g. `originalPositionFor` → `Trace speed (random)` and `Trace speed (ascending)`); the rest is rig noise.

Two new env vars on `benchmarks/jridgewell/trace.mjs` and `benchmarks/jridgewell/generate.mjs` (default behavior unchanged):

- `SOLO=1` — run only `source-map-js current` cases. Skips every third-party library and `source-map-js latest`. Memory tracking and Benchmark.Suite cases for those libraries are gated behind `if (SOLO) { /* skip */ } else if (DIFF) { ... } else { ... }`.
- `PHASES=key1,key2` — run only the named Benchmark.Suite phases.
  - `trace.mjs`: `init`, `trace-random`, `trace-ascending`, `genpos-init`, `genpos-speed`
  - `generate.mjs`: `adding`, `generate`

Compose with the existing `FILE=<map>` env and the `<which>` arg of `bench-diff.sh`. Example for a change isolated to `originalPositionFor`:

```sh
SOLO=1 PHASES=trace-random,trace-ascending FILE=preact.js.map \
  scripts/bench-diff.sh main trace
```

That run completes in ~30 seconds (vs ~50 minutes for the full all-fixtures `both` mode) while preserving the two-process methodology that avoids the V8 cross-module init bias documented in `scripts/bench-diff.sh`.

## Conflicts

None — additive env-var checks. With both vars unset, the bench produces byte-identical output to before.

## Validation

- `node --check benchmarks/jridgewell/trace.mjs` and `node --check benchmarks/jridgewell/generate.mjs` pass.
- Smoke run with `SOLO=1 PHASES=trace-random FILE=preact.js.map yarn bench:jridgewell:trace` produces only the `Memory Usage` block + `Trace speed (random)` line for `source-map-js current` and exits cleanly.
- Full `bench-diff.sh` run with all four scopes (`SOLO=1 PHASES=trace-random,trace-ascending FILE=preact.js.map scripts/bench-diff.sh main trace`) produces a clean delta table with two rows.