### PR TITLE
perf: read precomputed absolute source URL in originalPositionFor

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -824,8 +824,10 @@ BasicSourceMapConsumer.prototype.originalPositionFor =
 
         var source = util.getArg(mapping, 'source', null);
         if (source !== null) {
-          source = this._sources.at(source);
-          source = util.computeSourceURL(this.sourceRoot, source, this._sourceMapURL);
+          // _absoluteSources is precomputed at construction time as
+          // computeSourceURL(sourceRoot, _sources.at(i), sourceMapURL) for
+          // each i. Indexing into it skips the per-call URL parse + resolve.
+          source = this._absoluteSources[source];
         }
         var name = util.getArg(mapping, 'name', null);
         if (name !== null) {


### PR DESCRIPTION
## Summary

`originalPositionFor` was re-resolving the source URL on every trace hit:

```js
source = this._sources.at(source);
source = util.computeSourceURL(this.sourceRoot, source, this._sourceMapURL);
```

The `BasicSourceMapConsumer` constructor already precomputes the same value per source index in `_absoluteSources` (`lib/source-map-consumer.js:356-358`):

```js
this._absoluteSources = this._sources.toArray().map(function (s) {
  return util.computeSourceURL(sourceRoot, s, aSourceMapURL);
});
```

So the hot path can index into it directly and skip the `_sources.at` call plus the `util.computeSourceURL` URL parse + resolve.

This is a pure memoization — `_absoluteSources[i]` is built as exactly `computeSourceURL(sourceRoot, _sources.at(i), sourceMapURL)`, which is what the inlined call returned. No behavior change, no API surface change.

## Bench table

Methodology: `SOLO=1 PHASES=trace-random,trace-ascending FILE=<fixture> scripts/bench-diff.sh main trace`, two-process. Two samples per fixture (four for `babel.min.js.map`, see footnote). Numbers below are sample means.

| Fixture            | Phase      | Cand (ops/s) | Base (ops/s) |     Δ |
|--------------------|------------|-------------:|-------------:|------:|
| amp.js.map         | random     |        26.5k |       13.75k |  **+93%** |
| amp.js.map         | ascending  |        63.4k |       20.25k | **+213%** |
| vscode.map         | random     |       126.9k |       113.0k |    +12.3% |
| vscode.map         | ascending  |       191.7k |       163.4k |    +17.3% |
| preact.js.map      | random     |        46.9k |        42.3k |    +11.0% |
| preact.js.map      | ascending  |        86.0k |        82.6k |     +4.2% |
| issue-41.js.map    | random     |       383.1k |       374.3k |     +2.4% |
| issue-41.js.map    | ascending  |       537.0k |       522.3k |     +2.8% |
| react.js.map       | random     |       356.5k |       363.7k |     −2.0% |
| react.js.map       | ascending  |       697.7k |       681.1k |     +2.4% |
| babel.min.js.map¹  | random     |        76.4k |        81.0k |     −5.7% |
| babel.min.js.map   | ascending  |       304.1k |       295.0k |     +3.1% |

¹ `babel.min.js.map` trace-random has unusually wide rig variance: Benchmark.js bailed out at 17–22 samples (vs ~95 elsewhere) with ±2–4% error bars (vs ~±0.5%), and the per-sample candidate ops/s spans 67k–82k across 4 runs. The −5.7% is well inside that envelope; the candidate is not consistently slower. Other phases on the same fixture sample normally and trend positive.

The wide spread tracks the relative cost of `computeSourceURL` per call. Maps with many distinct sources or complex paths (amp, vscode, preact) saw the biggest gains. Maps with simpler paths or where per-call cost is dominated by other work move within the rig's noise band.

## Conflicts

None expected. The change is local to `originalPositionFor` and reads from a field that has existed since the consumer was introduced.

## Validation

- `yarn test` — 177 pass / 0 fail / 8 todo (matches baseline).
- `yarn test:coverage` — line 98.13% / branch 97.05% / func 96.67%, above the 98 / 97 / 96 thresholds.
- Bench above; the focused-mode env vars (`SOLO`, `PHASES`) come from #48.