### PR TITLE
perf: memoize _findSourceIndex string→index lookups

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -67,6 +67,10 @@ SourceMapConsumer.prototype._opfLine = -1;
 SourceMapConsumer.prototype._opfColumn = -1;
 SourceMapConsumer.prototype._opfIndex = -1;
 
+// Cache for `_findSourceIndex` string→integer-index lookups. Lazy on first
+// call. See the method body for the rationale.
+SourceMapConsumer.prototype._sourceIndexCache = null;
+
 SourceMapConsumer.prototype.__generatedMappings = null;
 Object.defineProperty(SourceMapConsumer.prototype, '_generatedMappings', {
   configurable: true,
@@ -372,25 +376,40 @@ BasicSourceMapConsumer.prototype.consumer = SourceMapConsumer;
  * found.
  */
 BasicSourceMapConsumer.prototype._findSourceIndex = function(aSource) {
+  // Memoize string→index lookups. Callers like
+  // `for (s of consumer.sources) consumer.generatedPositionFor({source: s, ...})`
+  // pass each absolute URL through here, and the unmemoized fallback below
+  // is an O(N) scan of `_absoluteSources`. Cache misses (-1) too so we
+  // don't re-scan when the source genuinely isn't in this consumer.
+  var cache = this._sourceIndexCache;
+  if (cache !== null) {
+    var cached = cache.get(aSource);
+    if (cached !== undefined) return cached;
+  } else {
+    cache = this._sourceIndexCache = new Map();
+  }
+
   var relativeSource = aSource;
   if (this.sourceRoot != null) {
     relativeSource = util.relative(this.sourceRoot, relativeSource);
   }
 
+  var idx = -1;
   if (this._sources.has(relativeSource)) {
-    return this._sources.indexOf(relativeSource);
-  }
-
-  // Maybe aSource is an absolute URL as returned by |sources|.  In
-  // this case we can't simply undo the transform.
-  var i;
-  for (i = 0; i < this._absoluteSources.length; ++i) {
-    if (this._absoluteSources[i] == aSource) {
-      return i;
+    idx = this._sources.indexOf(relativeSource);
+  } else {
+    // Maybe aSource is an absolute URL as returned by |sources|.  In
+    // this case we can't simply undo the transform.
+    for (var i = 0; i < this._absoluteSources.length; ++i) {
+      if (this._absoluteSources[i] == aSource) {
+        idx = i;
+        break;
+      }
     }
   }
 
-  return -1;
+  cache.set(aSource, idx);
+  return idx;
 };
 
 /**


### PR DESCRIPTION
## Summary

`_findSourceIndex(aSource)` returns the integer index of a source in `_sources`. The fast path (`_sources.has(relativeSource)`) only fires when the input matches a stored relative-source string. The fallback iterates `_absoluteSources` linearly — O(N) per call.

The typical loop pattern is:

```js
for (const source of consumer.sources) {
  consumer.generatedPositionFor({ source, line, column });
}
```

`consumer.sources` returns `_absoluteSources`, so every iteration calls `_findSourceIndex` with an absolute URL. On maps where the absolute form doesn't round-trip through the relative-source check (e.g. amp.js.map), the fallback runs every call → O(N²) just for source lookups, dwarfing the binary search inside `generatedPositionFor`.

Add `_sourceIndexCache`, a lazily-allocated `Map<string, number>`. First call populates it, subsequent calls short-circuit. Misses (-1) are cached too, so we don't re-scan for sources that genuinely aren't present.

Helps `generatedPositionFor`, `allGeneratedPositionsFor`, `sourceContentFor`, and the `IndexedSourceMapConsumer` source-validity check at line 1228.

## Bench table

Methodology: `SOLO=1 PHASES=genpos-init,genpos-speed FILE=<fixture> scripts/bench-diff.sh main trace`, two-process, two samples per fixture. Numbers below are sample means; ops/s.

| Fixture            | Phase           | Cand (ops/s) | Base (ops/s) |     Δ |
|--------------------|-----------------|-------------:|-------------:|------:|
| amp.js.map         | init            |          248 |          241 |    +3.2% |
| amp.js.map         | speed           |       25.95k |       14.95k | **+73.4%** |
| issue-41.js.map    | init            |         31.5 |         32.0 |    -1.3% |
| issue-41.js.map    | speed           |        1.41M |        1.31M |    +7.6% |
| preact.js.map      | init            |        6.75k |        6.80k |    -1.0% |
| preact.js.map      | speed           |       559.1k |       536.4k |    +4.3% |
| react.js.map       | init            |        2.20k |        2.25k |    -1.1% |
| react.js.map       | speed           |        7.67M |        7.41M |    +3.5% |
| babel.min.js.map   | init            |         27.0 |         28.5 |    -3.4% |
| babel.min.js.map   | speed           |        4.16M |        4.13M |    +0.9% |
| vscode.map         | init            |          5.0 |          5.0 |    -1.2% |
| vscode.map         | speed           |        1.10k |        1.10k |    +0.1% |

The big amp gain matches the diagnosis: amp's sources don't round-trip through `_sources.has(util.relative(sourceRoot, absoluteURL))`, so every call hit the linear-scan fallback. Maps that already short-circuit through the relative-source branch (preact, react, vscode, babel.min) gain only what the Map.get saves over the first ArraySet.indexOf — a few percent at most. Init-phase numbers are within rig noise (~±3%); the cache doesn't help when each iteration creates a fresh consumer.

## Conflicts

None expected. The change is local to `_findSourceIndex` plus one prototype field declaration.

## Validation

- `yarn test` — 177 pass / 0 fail / 8 todo (matches baseline).
- `yarn test:coverage` — line 98.14% / branch 97.08% / func 96.67%, above the 98 / 97 / 96 thresholds.
- Bench above (depends on #48's `SOLO`/`PHASES` filters in main).