### PR TITLE
perf: drop util.getArg on always-set mapping fields in hot paths

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -237,8 +237,8 @@ SourceMapConsumer.prototype.allGeneratedPositionsFor =
         // the line we found.
         while (mapping && mapping.originalLine === originalLine) {
           mappings.push({
-            line: util.getArg(mapping, 'generatedLine', null),
-            column: util.getArg(mapping, 'generatedColumn', null),
+            line: mapping.generatedLine,
+            column: mapping.generatedColumn,
             lastColumn: util.getArg(mapping, 'lastGeneratedColumn', null)
           });
 
@@ -255,8 +255,8 @@ SourceMapConsumer.prototype.allGeneratedPositionsFor =
                mapping.originalLine === line &&
                mapping.originalColumn == originalColumn) {
           mappings.push({
-            line: util.getArg(mapping, 'generatedLine', null),
-            column: util.getArg(mapping, 'generatedColumn', null),
+            line: mapping.generatedLine,
+            column: mapping.generatedColumn,
             lastColumn: util.getArg(mapping, 'lastGeneratedColumn', null)
           });
 
@@ -822,21 +822,24 @@ BasicSourceMapConsumer.prototype.originalPositionFor =
           this._opfIndex = index;
         }
 
-        var source = util.getArg(mapping, 'source', null);
+        // _parseMappings always sets `source`, `name`, `originalLine`, and
+        // `originalColumn` — null when unset, integer index otherwise — so a
+        // direct property read is correct and skips the getArg `in` check.
+        var source = mapping.source;
         if (source !== null) {
           // _absoluteSources is precomputed at construction time as
           // computeSourceURL(sourceRoot, _sources.at(i), sourceMapURL) for
           // each i. Indexing into it skips the per-call URL parse + resolve.
           source = this._absoluteSources[source];
         }
-        var name = util.getArg(mapping, 'name', null);
+        var name = mapping.name;
         if (name !== null) {
           name = this._names.at(name);
         }
         return {
           source: source,
-          line: util.getArg(mapping, 'originalLine', null),
-          column: util.getArg(mapping, 'originalColumn', null),
+          line: mapping.originalLine,
+          column: mapping.originalColumn,
           name: name
         };
       }
@@ -969,9 +972,12 @@ BasicSourceMapConsumer.prototype.generatedPositionFor =
       var mapping = this._originalMappings[index];
 
       if (mapping.source === needle.source) {
+        // generatedLine and generatedColumn are always set by _parseMappings;
+        // lastGeneratedColumn is added optionally by computeColumnSpans, so
+        // keep getArg there.
         return {
-          line: util.getArg(mapping, 'generatedLine', null),
-          column: util.getArg(mapping, 'generatedColumn', null),
+          line: mapping.generatedLine,
+          column: mapping.generatedColumn,
           lastColumn: util.getArg(mapping, 'lastGeneratedColumn', null)
         };
       }


### PR DESCRIPTION
## Summary

`originalPositionFor`, `generatedPositionFor`, and `allGeneratedPositionsFor` build their result objects with `util.getArg(mapping, '<field>', null)`. `getArg` does an `'<field>' in obj` check + a function call per read.

`_parseMappings` (and `IndexedSourceMapConsumer._parseMappings`) initialize every mapping with `generatedLine`, `generatedColumn`, `source`, `originalLine`, `originalColumn`, and `name` — null when unset, integer otherwise — so the field is always present on parsed mappings. The `getArg` indirection adds no value there; replace with direct property access.

`lastGeneratedColumn` keeps `getArg` because `computeColumnSpans` adds it lazily and parsed mappings don't have it by default. Stripping the check there would either change behavior (returning `undefined` instead of `null`) or require an extra ternary that drops branch coverage below the 97% threshold.

The gain is much larger than expected (handoff predicted 1-3%) because the warm-start cache fast paths landed in #45/#47 already eliminated the per-call binary-search work. After that, the `getArg` calls were a major fraction of the remaining per-call work in the cache-hit path.

## Bench table

Methodology: `SOLO=1 PHASES=trace-random,trace-ascending,genpos-speed FILE=<fixture> scripts/bench-diff.sh main trace`, two-process, two samples per fixture. Numbers below are sample means; ops/s.

| Fixture            | Phase             | Cand (ops/s) | Base (ops/s) |     Δ |
|--------------------|-------------------|-------------:|-------------:|------:|
| amp.js.map         | OPF random        |        35.5k |        26.8k | **+32.2%** |
| amp.js.map         | OPF ascending     |       135.9k |        64.7k | **+109.9%** |
| amp.js.map         | GPF speed         |        15.8k |        15.3k |     +3.3% |
| preact.js.map      | OPF random        |        66.4k |        46.7k | **+42.2%** |
| preact.js.map      | OPF ascending     |       186.9k |        88.0k | **+112.6%** |
| preact.js.map      | GPF speed         |       567.8k |       544.6k |     +4.2% |
| react.js.map       | OPF random        |       488.0k |       361.0k | **+35.2%** |
| react.js.map       | OPF ascending     |        1.49M |       709.6k | **+110.2%** |
| react.js.map       | GPF speed         |        7.15M |        7.06M |     +1.3% |
| issue-41.js.map    | OPF random        |       454.9k |       370.9k |    +22.6% |
| issue-41.js.map    | OPF ascending     |       693.1k |       531.6k |    +30.7% |
| issue-41.js.map    | GPF speed         |        1.50M |        1.39M |     +8.1% |
| vscode.map         | OPF random        |       151.9k |       126.2k |    +20.4% |
| vscode.map         | OPF ascending     |       241.9k |       200.0k |    +20.9% |
| vscode.map         | GPF speed         |         998  |         973  |     +5.0% |
| babel.min.js.map¹  | OPF random        |        88.2k |        83.6k |     +5.3% |
| babel.min.js.map   | OPF ascending     |       536.9k |       305.4k | **+76.0%** |
| babel.min.js.map   | GPF speed         |        4.43M |        4.17M |     +6.3% |

¹ `babel.min.js.map` OPF random has the same wide-rig-variance behavior documented in #49 (Benchmark.js bails out at fewer samples with high error bars). The trend across both samples is positive.

GPF speed shows smaller gains because most of GPF's per-call cost is in `_findSourceIndex` (addressed separately in #50, not stacked here).

## Conflicts

None expected. The change is local to three result builders.

## Validation

- `yarn test` — 177 pass / 0 fail / 8 todo (matches baseline).
- `yarn test:coverage` — line 98.14% / branch 97.05% / func 96.67%, above the 98 / 97 / 96 thresholds.