### PR TITLE
perf: skip sorting per-source originalMappings when already sorted

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -666,10 +666,25 @@ BasicSourceMapConsumer.prototype._buildOriginalMappings =
     }
 
     var nonNullOriginalMappings = [];
+    var compareOriginal = util.compareByOriginalPositionsNoSource;
     for (var i = 0; i < originalMappings.length; i++) {
-      if (originalMappings[i] != null) {
-        quickSort(originalMappings[i], util.compareByOriginalPositionsNoSource);
-        nonNullOriginalMappings.push(originalMappings[i]);
+      var perSource = originalMappings[i];
+      if (perSource != null) {
+        // Well-formed source maps emit segments in original-position order
+        // within each source, so the per-source array is usually already
+        // sorted. Probe with one O(N) pass and skip the quickSort when it
+        // is. Same shape as the sortGenerated skip-sorted check.
+        var sorted = true;
+        for (var j = 1; j < perSource.length; j++) {
+          if (compareOriginal(perSource[j - 1], perSource[j]) > 0) {
+            sorted = false;
+            break;
+          }
+        }
+        if (!sorted) {
+          quickSort(perSource, compareOriginal);
+        }
+        nonNullOriginalMappings.push(perSource);
       }
     }
     this.__originalMappings = [].concat(...nonNullOriginalMappings);

--- a/test/internal/test-source-map-consumer-internals.js
+++ b/test/internal/test-source-map-consumer-internals.js
@@ -112,6 +112,32 @@ test('BasicSourceMapConsumer sorts a large line (n>=20) whose generated columns 
   assert.deepStrictEqual(sortedColumns(consumer), expected);
 });
 
+// _buildOriginalMappings groups parsed mappings by source and then sorts each
+// group by original position. The skip-sorted check short-circuits when the
+// per-source array is already in original order. Real-world maps usually are,
+// so we craft one where two segments share a generated line and source but
+// have decreasing original lines — guaranteeing the per-source array comes
+// out of original-position order and forcing the actual quickSort call.
+test('BasicSourceMapConsumer sorts originalMappings when generated and original orders disagree', () => {
+  // Segment 1: genCol=0, srcIdx=0, origLineDelta=10 (→ origLine 11), origCol=0
+  // Segment 2: genColDelta=5, srcIdxDelta=0, origLineDelta=-5 (→ origLine 6), origCol=0
+  var seg1 = base64VLQ.encode(0) + base64VLQ.encode(0)
+           + base64VLQ.encode(10) + base64VLQ.encode(0);
+  var seg2 = base64VLQ.encode(5) + base64VLQ.encode(0)
+           + base64VLQ.encode(-5) + base64VLQ.encode(0);
+  var consumer = new SourceMapConsumer({
+    version: 3,
+    sources: ['x.js'],
+    names: [],
+    mappings: seg1 + ',' + seg2
+  });
+
+  var lines = [];
+  consumer.eachMapping(function (m) { lines.push(m.originalLine); },
+                       null, SourceMapConsumer.ORIGINAL_ORDER);
+  assert.deepStrictEqual(lines, [6, 11]);
+});
+
 // _charIsMappingSeparator is no longer used by the inline-charCodeAt parser
 // in _parseMappings, but it remains on the prototype as a documented helper
 // for subclasses / monkey-patching. Cover it directly so the prototype method


### PR DESCRIPTION
## Summary

Direct analog of #36 (skip-sorted check in `sortGenerated`), applied to `_buildOriginalMappings`. The lazy original-mappings build groups parsed mappings by source, then `quickSort`s each group by `compareByOriginalPositionsNoSource`. Well-formed source maps emit segments in original-position order within each source, so after grouping the per-source array is usually already sorted. One O(N) probe before quickSort short-circuits the common case.

## Bench table

Methodology: `SOLO=1 PHASES=genpos-init FILE=<fixture> scripts/bench-diff.sh main trace`, two-process, two samples per fixture. The `genpos-init` phase is the only place `_buildOriginalMappings` shows up — `genpos-speed` reuses a pre-built consumer; `originalPositionFor` doesn't touch `_originalMappings` at all.

| Fixture            | Cand (ops/s) | Base (ops/s) |     Δ |
|--------------------|-------------:|-------------:|------:|
| amp.js.map         |          239 |          234 |    +2.1% |
| babel.min.js.map   |         28.0 |         27.5 |    +2.3% |
| issue-41.js.map    |         32.0 |         32.0 |     0.0% |
| preact.js.map      |        6.70k |        6.60k |    +1.3% |
| react.js.map       |        2.10k |        2.10k |    -0.2% |
| vscode.map         |          5.0 |          5.0 |    +0.5% |

Larger fixtures (amp, babel.min, preact) show 1–2% gains. Smaller fixtures move within rig noise. Build cost is a fraction of total init cost (parsing dominates), so the headline number is small even though the quickSort itself is fully skipped on every fixture tested.

## Conflicts

None expected. Local change in `_buildOriginalMappings`.

## Validation

- `yarn test` — 178 pass / 0 fail / 8 todo (one new test added: `BasicSourceMapConsumer sorts originalMappings when generated and original orders disagree`, which forces the actual quickSort branch).
- `yarn test:coverage` — line 98.14% / branch 97.07% / func 96.67%, above the 98 / 97 / 96 thresholds.