### PR TITLE
perf: index into _absoluteSources in eachMapping

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -165,20 +165,18 @@ SourceMapConsumer.prototype.eachMapping =
       throw new Error("Unknown order of iteration.");
     }
 
-    var sourceRoot = this.sourceRoot;
     var boundCallback = aCallback.bind(context);
     var names = this._names;
-    var sources = this._sources;
-    var sourceMapURL = this._sourceMapURL;
+    // `_absoluteSources` is precomputed in both consumer constructors as
+    // `computeSourceURL(sourceRoot, _sources.at(i), sourceMapURL)`, so a
+    // direct index skips the per-call URL parse + resolve. Same memoization
+    // pattern used by `originalPositionFor` (PR #49).
+    var absoluteSources = this._absoluteSources;
 
     for (var i = 0, n = mappings.length; i < n; i++) {
       var mapping = mappings[i];
-      var source = mapping.source === null ? null : sources.at(mapping.source);
-      if(source !== null) {
-        source = util.computeSourceURL(sourceRoot, source, sourceMapURL);
-      }
       boundCallback({
-        source: source,
+        source: mapping.source === null ? null : absoluteSources[mapping.source],
         generatedLine: mapping.generatedLine,
         generatedColumn: mapping.generatedColumn,
         originalLine: mapping.originalLine,
@@ -1422,6 +1420,13 @@ IndexedSourceMapConsumer.prototype._parseMappings =
         }
       }
     }
+
+    // `_sources` is populated with already-absolute URLs (lines above resolve
+    // each section's source through `computeSourceURL`), so the absolute view
+    // is simply the ArraySet's toArray. Mirroring the field that
+    // BasicSourceMapConsumer sets in its constructor lets `eachMapping` index
+    // into `_absoluteSources` uniformly across consumer types.
+    this._absoluteSources = this._sources.toArray();
 
     quickSort(this.__generatedMappings, util.compareByGeneratedPositionsDeflated);
     quickSort(this.__originalMappings, util.compareByOriginalPositions);


### PR DESCRIPTION
## Summary

Third call site of the same memoization #49 applied to `originalPositionFor`. `eachMapping` walked `_generatedMappings` / `_originalMappings` and called `util.computeSourceURL(sourceRoot, _sources.at(i), sourceMapURL)` on each entry. The constructor already precomputes that exact expression per source index into `_absoluteSources`; reading from it directly skips the URL parse + resolve per call.

For `IndexedSourceMapConsumer`, `_sources` is populated with already-absolute URLs (resolved per section during `_parseMappings`), so `_absoluteSources = _sources.toArray()` at the end of that method gives both consumer types the same field for `eachMapping` to index into.

## Bench table

Methodology: `SOLO=1 PHASES=eachmapping-generated,eachmapping-original FILE=<fixture> scripts/bench-diff.sh main trace`, two-process. Two samples per fixture per phase; numbers below are sample means (ops/s). The `eachmapping-*` phases come from #55, which adds them to the rig.

| Fixture            | Phase     | Cand (ops/s) | Base (ops/s) |       Δ |
|--------------------|-----------|-------------:|-------------:|--------:|
| amp.js.map         | generated |        3.55k |          471 | **+654%** |
| amp.js.map         | original  |        3.50k |          483 | **+625%** |
| preact.js.map      | generated |       184.1k |        35.5k | **+419%** |
| preact.js.map      | original  |       180.6k |        35.7k | **+406%** |
| issue-41.js.map    | generated |          425 |          229 |  +86.0% |
| issue-41.js.map    | original  |          423 |          225 |  +88.0% |
| vscode.map         | generated |         55.0 |         29.0 |  +88.7% |
| vscode.map         | original  |         54.5 |         29.0 |  +85.6% |
| react.js.map       | generated |        54.7k |        32.5k |  +68.7% |
| react.js.map       | original  |        54.4k |        31.9k |  +70.6% |
| babel.min.js.map   | generated |          369 |          262 |  +40.7% |
| babel.min.js.map   | original  |          370 |          258 |  +43.8% |

`computeSourceURL` does URL parsing + normalization on every call. For maps that walk thousands of mappings — the typical `eachMapping` workload — the cost compounds. amp/preact see the biggest gains because their absolute URLs are particularly expensive to resolve (long paths, lots of normalization), so the precompute saves the most per call.

## Conflicts

None. Two-site change: one new line at the end of `IndexedSourceMapConsumer._parseMappings`, plus the swap inside `eachMapping`.

## Validation

- `yarn test` — 178 pass / 0 fail / 8 todo. Existing tests cover `eachMapping` for both `BasicSourceMapConsumer` and `IndexedSourceMapConsumer` (e.g. `test/public/test-source-map-consumer.js:237, :295, :320`).
- `yarn test:coverage` — line 98.20% / branch 97.13% / func 96.67%, above the 98 / 97 / 96 thresholds.
- Bench above. Depends on #55 for the `eachmapping-*` phase keys; the `_absoluteSources` field on `IndexedSourceMapConsumer` is new but every test that hits `eachMapping` on an indexed consumer exercises it.