### PR TITLE
chore(bench): add eachMapping phases to jridgewell bench

### DIFF
--- a/benchmarks/jridgewell/trace.mjs
+++ b/benchmarks/jridgewell/trace.mjs
@@ -27,7 +27,8 @@ const { DIFF, FILE, SOLO, PHASES } = process.env;
 // pure runtime tax for bench-diff.sh.
 //
 // PHASES=key1,key2: only run the named Benchmark.Suite phases. Keys:
-//   init, trace-random, trace-ascending, genpos-init, genpos-speed
+//   init, trace-random, trace-ascending, genpos-init, genpos-speed,
+//   eachmapping-generated, eachmapping-original
 // Default (unset) runs all phases.
 const phasesSet = PHASES ? new Set(PHASES.split(',').map((s) => s.trim())) : null;
 const phaseEnabled = (key) => !phasesSet || phasesSet.has(key);
@@ -478,6 +479,74 @@ async function bench(file) {
         for (const source of chromeMap2026.sources()) {
           chromeMap2026.findEntryReversed(source, 6);
         }
+      });
+  }
+  benchmark
+    .on('error', (event) => console.error(event.target.error))
+    .on('cycle', (event) => {
+      console.log(String(event.target));
+    })
+    .on('complete', function () {
+      console.log('Fastest is ' + this.filter('fastest').map('name'));
+    })
+    .run({});
+  }
+
+  // eachMapping phases iterate every parsed mapping and run a no-op callback,
+  // measuring per-mapping iteration cost (source URL resolution + name lookup
+  // + result-object construction). Pre-built `_generatedMappings` and
+  // `_originalMappings` from the Memory Usage / Init / Generated Positions
+  // calls above carry over, so the build cost isn't included.
+  const NOOP = () => {};
+
+  if (phaseEnabled('eachmapping-generated')) {
+  console.log('eachMapping speed (generated order):');
+  benchmark = new Benchmark.Suite()
+    .add('source-map-js current: encoded eachMapping', () => {
+      smcjsCurrent.eachMapping(NOOP);
+    });
+  if (SOLO) {
+    // only source-map-js current
+  } else if (DIFF) {
+    benchmark = benchmark.add('source-map-js latest: encoded eachMapping', () => {
+      smcjsLatest.eachMapping(NOOP);
+    });
+  } else {
+    benchmark = benchmark
+      .add('source-map-0.6.1: encoded eachMapping', () => {
+        smc061.eachMapping(NOOP);
+      });
+  }
+  benchmark
+    .on('error', (event) => console.error(event.target.error))
+    .on('cycle', (event) => {
+      console.log(String(event.target));
+    })
+    .on('complete', function () {
+      console.log('Fastest is ' + this.filter('fastest').map('name'));
+    })
+    .run({});
+
+  console.log('');
+  }
+
+  if (phaseEnabled('eachmapping-original')) {
+  console.log('eachMapping speed (original order):');
+  const ORIG = CurrentSourceMapConsumer.ORIGINAL_ORDER;
+  benchmark = new Benchmark.Suite()
+    .add('source-map-js current: encoded eachMapping', () => {
+      smcjsCurrent.eachMapping(NOOP, null, ORIG);
+    });
+  if (SOLO) {
+    // only source-map-js current
+  } else if (DIFF) {
+    benchmark = benchmark.add('source-map-js latest: encoded eachMapping', () => {
+      smcjsLatest.eachMapping(NOOP, null, SourceMapConsumerJsLatest.ORIGINAL_ORDER);
+    });
+  } else {
+    benchmark = benchmark
+      .add('source-map-0.6.1: encoded eachMapping', () => {
+        smc061.eachMapping(NOOP, null, SourceMapConsumer061.ORIGINAL_ORDER);
       });
   }
   benchmark

--- a/scripts/bench-delta.js
+++ b/scripts/bench-delta.js
@@ -21,6 +21,8 @@ const SUITE_HEADERS = new Set([
   'Trace speed (ascending)',
   'Generated Positions init',
   'Generated Positions speed',
+  'eachMapping speed (generated order)',
+  'eachMapping speed (original order)',
   'Adding speed',
   'Generate speed',
 ]);
@@ -45,8 +47,8 @@ function parse(text) {
       continue;
     }
 
-    // Suite header: e.g. "Init speed:"
-    m = /^([A-Z][\w()\s]+):\s*$/.exec(line);
+    // Suite header: e.g. "Init speed:" or "eachMapping speed (generated order):"
+    m = /^([A-Za-z][\w()\s]+):\s*$/.exec(line);
     if (m && SUITE_HEADERS.has(m[1])) { suite = m[1]; continue; }
 
     // Result line: "source-map-js current[:] <op> x 3,398 ops/sec ..."


### PR DESCRIPTION
## Summary

The trace bench rig (`benchmarks/jridgewell/trace.mjs`) had no \`eachMapping\` phase, which made it impossible to measure changes that touch the per-mapping result-building path inside \`eachMapping\` — e.g. swapping the per-call \`util.computeSourceURL(...)\` for an \`_absoluteSources[i]\` index. Add two phases:

- \`eachmapping-generated\` — \`consumer.eachMapping(noop)\` (default GENERATED_ORDER walk).
- \`eachmapping-original\` — \`consumer.eachMapping(noop, null, ORIGINAL_ORDER)\`.

Both run on the already-warmed-up \`smcjsCurrent\` from the Memory Usage section. \`_generatedMappings\` and \`_originalMappings\` are pre-built by the calls earlier in \`bench()\`, so the reported ops/sec measure only the iteration itself, not the lazy build.

\`PHASES\` env-var doc updated with the new keys. \`bench-delta.js\`'s suite-header regex relaxed from \`[A-Z]\` to \`[A-Za-z]\` so the \`eachMapping speed (...)\` headers are recognized — there's no other place that generates a header-shaped line, so the relaxation is safe.

## Conflicts

None expected. Additive: two new phase blocks at the end of \`bench()\`, plus two new entries in \`SUITE_HEADERS\` and the regex tweak.

## Validation

- \`node --check benchmarks/jridgewell/trace.mjs\` and \`node --check scripts/bench-delta.js\` both pass.
- \`SOLO=1 PHASES=eachmapping-generated,eachmapping-original FILE=preact.js.map yarn bench:jridgewell:trace\` produces the expected output: ~35k ops/sec on both orders, no errors.
- Self-vs-self \`bench-diff.sh\` (chore branch vs main, with identical lib code) shows ±0.3% on both phases — rig noise floor, parser correctly identifies the new headers and pairs the rows.