### PR TITLE
perf: bucket-by-source sort in BasicSourceMapConsumer.fromSourceMap

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -449,7 +449,11 @@ BasicSourceMapConsumer.fromSourceMap =
 
     var generatedMappings = aSourceMap._mappings.toArray().slice();
     var destGeneratedMappings = smc.__generatedMappings = [];
-    var destOriginalMappings = smc.__originalMappings = [];
+    // Bucket original-side mappings by source index — same pattern as
+    // _buildOriginalMappings and IndexedSourceMapConsumer._parseMappings —
+    // so the per-bucket sort can use compareByOriginalPositionsNoSource and
+    // skip the function-call strcmp(source, source) primary key.
+    var originalBuckets = [];
 
     for (var i = 0, length = generatedMappings.length; i < length; i++) {
       var srcMapping = generatedMappings[i];
@@ -458,7 +462,8 @@ BasicSourceMapConsumer.fromSourceMap =
       destMapping.generatedColumn = srcMapping.generatedColumn;
 
       if (srcMapping.source) {
-        destMapping.source = sources.indexOf(srcMapping.source);
+        var sourceIdx = sources.indexOf(srcMapping.source);
+        destMapping.source = sourceIdx;
         destMapping.originalLine = srcMapping.originalLine;
         destMapping.originalColumn = srcMapping.originalColumn;
 
@@ -466,13 +471,39 @@ BasicSourceMapConsumer.fromSourceMap =
           destMapping.name = names.indexOf(srcMapping.name);
         }
 
-        destOriginalMappings.push(destMapping);
+        while (originalBuckets.length <= sourceIdx) {
+          originalBuckets.push(null);
+        }
+        if (originalBuckets[sourceIdx] === null) {
+          originalBuckets[sourceIdx] = [];
+        }
+        originalBuckets[sourceIdx].push(destMapping);
       }
 
       destGeneratedMappings.push(destMapping);
     }
 
-    quickSort(smc.__originalMappings, util.compareByOriginalPositions);
+    var nonNullBuckets = [];
+    var compareOriginal = util.compareByOriginalPositionsNoSource;
+    for (var b = 0; b < originalBuckets.length; b++) {
+      var perSource = originalBuckets[b];
+      if (perSource != null) {
+        // Well-formed input usually emits per-source mappings already in
+        // original-position order — probe and skip the sort when it is.
+        var sorted = true;
+        for (var k = 1; k < perSource.length; k++) {
+          if (compareOriginal(perSource[k - 1], perSource[k]) > 0) {
+            sorted = false;
+            break;
+          }
+        }
+        if (!sorted) {
+          quickSort(perSource, compareOriginal);
+        }
+        nonNullBuckets.push(perSource);
+      }
+    }
+    smc.__originalMappings = [].concat(...nonNullBuckets);
 
     return smc;
   };

--- a/scripts/bench-fromsourcemap.js
+++ b/scripts/bench-fromsourcemap.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/* eslint-env node */
+//
+// bench-fromsourcemap.js — focused microbench for
+// BasicSourceMapConsumer.fromSourceMap.
+//
+// The jridgewell trace/generate fixtures don't exercise the
+// `SourceMapConsumer.fromSourceMap(generator)` path — the one used by
+// roundtrip / applySourceMap workflows. This script primes a
+// SourceMapGenerator from each fixture via SourceMapGenerator.fromSourceMap,
+// then times SourceMapConsumer.fromSourceMap on that generator.
+//
+// Usage:
+//   node scripts/bench-fromsourcemap.js              # all fixtures
+//   node scripts/bench-fromsourcemap.js babel.min    # one fixture (prefix match)
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const Benchmark = require('benchmark');
+const { SourceMapConsumer, SourceMapGenerator } = require('../source-map.js');
+
+const FIXTURES_DIR = path.join(__dirname, '..', 'benchmarks', 'jridgewell', 'fixtures');
+const ONLY = process.argv[2];
+
+const fixtures = fs.readdirSync(FIXTURES_DIR)
+  .filter((f) => f.endsWith('.map') || f.endsWith('.js.map'))
+  .filter((f) => !ONLY || f.startsWith(ONLY));
+
+if (fixtures.length === 0) {
+  console.error('No fixtures matched.');
+  process.exit(1);
+}
+
+for (const file of fixtures) {
+  const raw = fs.readFileSync(path.join(FIXTURES_DIR, file), 'utf8');
+  let map;
+  try { map = JSON.parse(raw); } catch (e) { continue; }
+  if (map.sections) continue;
+  if (!map.mappings) continue;
+
+  // Build the generator once outside the timed loop — fromSourceMap is what
+  // we're measuring, not parse/generate.
+  const consumer = new SourceMapConsumer(map);
+  const generator = SourceMapGenerator.fromSourceMap(consumer);
+
+  const segments = (map.mappings.match(/[,;]/g) || []).length + 1;
+  console.log('');
+  console.log(file + ' - ' + segments + ' segments');
+  console.log('SourceMapConsumer.fromSourceMap speed:');
+
+  const suite = new Benchmark.Suite()
+    .add('source-map-js current: fromSourceMap', () => {
+      SourceMapConsumer.fromSourceMap(generator);
+    })
+    .on('cycle', (ev) => { console.log('  ' + String(ev.target)); })
+    .on('complete', function () {
+      console.log('  Fastest is ' + this.filter('fastest').map('name'));
+    });
+
+  suite.run({ async: false });
+}

--- a/test/internal/test-source-map-consumer-internals.js
+++ b/test/internal/test-source-map-consumer-internals.js
@@ -19,6 +19,7 @@ var SourceMapConsumer = consumerModule.SourceMapConsumer;
 var BasicSourceMapConsumer = consumerModule.BasicSourceMapConsumer;
 var IndexedSourceMapConsumer = consumerModule.IndexedSourceMapConsumer;
 var base64VLQ = require('../../lib/base64-vlq');
+var SourceMapGenerator = require('../../lib/source-map-generator').SourceMapGenerator;
 
 // Build a single-line mappings string from generated-column values.
 // Each segment is just (genColumn delta), so the resulting line has
@@ -163,6 +164,32 @@ test('IndexedSourceMapConsumer sorts per-source originalMappings when bucket is 
     ]
   });
 
+  var lines = [];
+  consumer.eachMapping(function (m) { lines.push(m.originalLine); },
+                       null, SourceMapConsumer.ORIGINAL_ORDER);
+  assert.deepStrictEqual(lines, [6, 11]);
+});
+
+// BasicSourceMapConsumer.fromSourceMap buckets original-side mappings by
+// source and sorts each bucket with compareByOriginalPositionsNoSource.
+// MappingList stores mappings in generated-position order, so we need two
+// mappings on the same source whose original positions decrease as their
+// generated columns increase — that produces an out-of-order bucket and
+// forces the quickSort fallback.
+test('BasicSourceMapConsumer.fromSourceMap sorts per-source originalMappings when bucket is out of order', () => {
+  var smg = new SourceMapGenerator({ file: 'foo.js' });
+  smg.addMapping({
+    source:    'x.js',
+    original:  { line: 11, column: 0 },
+    generated: { line:  1, column: 0 }
+  });
+  smg.addMapping({
+    source:    'x.js',
+    original:  { line:  6, column: 0 },
+    generated: { line:  1, column: 5 }
+  });
+
+  var consumer = SourceMapConsumer.fromSourceMap(smg);
   var lines = [];
   consumer.eachMapping(function (m) { lines.push(m.originalLine); },
                        null, SourceMapConsumer.ORIGINAL_ORDER);


### PR DESCRIPTION
## Summary

`BasicSourceMapConsumer.fromSourceMap` previously collected `__originalMappings` into a single flat array and finished with `quickSort(.., compareByOriginalPositions)` — that comparator does `strcmp(source, source)` as the primary key, which is a function call on every compare in the inner sort loop. On `vscode.map` (2M+ segments, many sources) this is the dominant cost.

This PR mirrors the bucket-by-source pattern now used in:
- `BasicSourceMapConsumer._buildOriginalMappings` (the encoded-mappings path)
- `IndexedSourceMapConsumer._parseMappings` (#56)

So all three places that produce `__originalMappings` use the same shape: collect into per-source buckets indexed by source-index, scan each bucket for sortedness, only call `quickSort(.., compareByOriginalPositionsNoSource)` when the scan finds an inversion, then `[].concat(...)`. Output ordering is identical (numeric source-index ascending matches the old `strcmp(numericIdx, numericIdx)`; within a bucket, the No-Source comparator's secondary keys are the same).

## Bench

The standard jridgewell trace/generate bench doesn't exercise the `SourceMapConsumer.fromSourceMap(generator)` path. This PR adds `scripts/bench-fromsourcemap.js`, which primes a `SourceMapGenerator` from each existing fixture (via `SourceMapGenerator.fromSourceMap(consumer)`) and times `SourceMapConsumer.fromSourceMap(generator)`.

Two-process bench (candidate = this branch, baseline = `main` overlaid, both `node v24.13.0`):

| Fixture | Segments | cand ops/sec | base ops/sec | Δ |
|---|---:|---:|---:|---:|
| amp.js.map | 45,120 | 224 | 184 | **+21.7%** |
| babel.min.js.map | 347,808 | 30.48 | 29.79 | +2.3% (within ±3% variance) |
| issue-41.js.map | 313,751 | 33.66 | 31.87 | **+5.6%** |
| preact.js.map | 1,992 | 8,357 | 6,864 | **+21.8%** |
| react.js.map | 5,734 | 2,697 | 2,528 | **+6.7%** |
| vscode.map | 2,142,931 | 4.09 | 2.70 | **+51.5%** |

Reproduce:
```
node scripts/bench-fromsourcemap.js
```

## Tests

- All 179 existing tests pass; added one internal test that builds a `SourceMapGenerator` with two same-source mappings whose original positions decrease as generated columns increase — forcing the per-source bucket to come out of order, covering the `quickSort` fallback (mirrors the tests added for `_buildOriginalMappings` in #52 and `IndexedSourceMapConsumer._parseMappings` in #56).
- `yarn test:coverage` passes 98/97/96:
  - `lib/source-map-consumer.js`: 99.93 / 99.07 / 97.30
  - all files: 98.23 / 97.17 / 96.67