### PR TITLE
perf: cache last source/name indexOf result in _serializeMappings

### DIFF
--- a/lib/source-map-generator.js
+++ b/lib/source-map-generator.js
@@ -352,6 +352,14 @@ SourceMapGenerator.prototype._serializeMappings =
     var nameIdx;
     var sourceIdx;
 
+    // Single-slot caches for the ArraySet.indexOf (Map.get) calls. Consecutive
+    // mappings almost always share source/name, so cache the last input→idx
+    // pair to skip the lookup on every match.
+    var lastSourceStr = null;
+    var lastSourceIdx = 0;
+    var lastNameStr = null;
+    var lastNameIdx = 0;
+
     var mappings = this._mappings.toArray();
     for (var i = 0, len = mappings.length; i < len; i++) {
       mapping = mappings[i];
@@ -378,7 +386,14 @@ SourceMapGenerator.prototype._serializeMappings =
       previousGeneratedColumn = mapping.generatedColumn;
 
       if (mapping.source != null) {
-        sourceIdx = this._sources.indexOf(mapping.source);
+        var srcStr = mapping.source;
+        if (srcStr === lastSourceStr) {
+          sourceIdx = lastSourceIdx;
+        } else {
+          sourceIdx = this._sources.indexOf(srcStr);
+          lastSourceStr = srcStr;
+          lastSourceIdx = sourceIdx;
+        }
         val = sourceIdx - previousSource;
         next += (val >= -15 && val <= 15) ? vlqEncodeTable[val + 15] : base64VLQ.encode(val);
         previousSource = sourceIdx;
@@ -393,7 +408,14 @@ SourceMapGenerator.prototype._serializeMappings =
         previousOriginalColumn = mapping.originalColumn;
 
         if (mapping.name != null) {
-          nameIdx = this._names.indexOf(mapping.name);
+          var nameStr = mapping.name;
+          if (nameStr === lastNameStr) {
+            nameIdx = lastNameIdx;
+          } else {
+            nameIdx = this._names.indexOf(nameStr);
+            lastNameStr = nameStr;
+            lastNameIdx = nameIdx;
+          }
           val = nameIdx - previousName;
           next += (val >= -15 && val <= 15) ? vlqEncodeTable[val + 15] : base64VLQ.encode(val);
           previousName = nameIdx;


### PR DESCRIPTION
## Summary

`SourceMapGenerator._serializeMappings` calls `this._sources.indexOf(mapping.source)` and `this._names.indexOf(mapping.name)` once per mapping. The underlying `ArraySet.indexOf` does a `Map.get(str)` — cheap individually, but consecutive mappings almost always share their source string (bundler output groups by source) and frequently share their name string too, so the lookup is mostly redundant.

This PR adds single-slot caches — `(lastSourceStr, lastSourceIdx)` and `(lastNameStr, lastNameIdx)` — kept across loop iterations. On a cache hit (same string as last call) we skip `indexOf`; on a miss we fall back and refresh the slot. Identity-checked with `===`, no allocation. Public surface unchanged.

## Bench

`scripts/bench-diff.sh main generate` (two-process, `SOLO=1 PHASES=generate`, node v24.13.0):

| Fixture | cand ops/sec | base ops/sec | Δ |
|---|---:|---:|---:|
| amp.js.map | 379 | 350 | **+8.3%** |
| babel.min.js.map | 54 | 53 | +1.9% |
| issue-41.js.map | 85 | 74 | **+14.8%** |
| preact.js.map | 10.6k | 10.2k | +4.0% |
| react.js.map | 4.0k | 3.8k | +4.0% |
| vscode.map | 6 | 6 | +5.0% |
| **mean** | | | **+6.3%** |

## Tests

- All 180 existing tests pass.
- `yarn test:coverage` thresholds (98/97/96) green:
  - `lib/source-map-generator.js`: 100/100/100
  - all files: 98.24 / 97.19 / 96.67