### PR TITLE
perf: inline getArg + drop redundant has() in addMapping

### DIFF
--- a/lib/source-map-generator.js
+++ b/lib/source-map-generator.js
@@ -102,10 +102,14 @@ SourceMapGenerator.fromSourceMap =
  */
 SourceMapGenerator.prototype.addMapping =
   function SourceMapGenerator_addMapping(aArgs) {
+    // Optional fields read directly — `aArgs.X` returns undefined when absent;
+    // downstream code uses `X != null` which treats undefined and null alike.
+    // The required `generated` keeps getArg so the missing-arg throw is
+    // preserved when validation is skipped.
     var generated = util.getArg(aArgs, 'generated');
-    var original = util.getArg(aArgs, 'original', null);
-    var source = util.getArg(aArgs, 'source', null);
-    var name = util.getArg(aArgs, 'name', null);
+    var original = aArgs.original != null ? aArgs.original : null;
+    var source = aArgs.source != null ? aArgs.source : null;
+    var name = aArgs.name != null ? aArgs.name : null;
 
     if (!this._skipValidation) {
       if (this._validateMapping(generated, original, source, name) === false) {
@@ -115,16 +119,14 @@ SourceMapGenerator.prototype.addMapping =
 
     if (source != null) {
       source = String(source);
-      if (!this._sources.has(source)) {
-        this._sources.add(source);
-      }
+      // ArraySet.add is idempotent (it does its own duplicate check), so the
+      // outer has() guard is redundant and just adds an extra function call.
+      this._sources.add(source);
     }
 
     if (name != null) {
       name = String(name);
-      if (!this._names.has(name)) {
-        this._names.add(name);
-      }
+      this._names.add(name);
     }
 
     this._mappings.add({


### PR DESCRIPTION
## Summary

`SourceMapGenerator.addMapping` is the per-mapping bottleneck on the generate side (per `bench-data-followups.md` #4 — `addMapping` is slower than encoded output throughput in every bench). Two small wins on the hot path:

1. **Inline three optional `getArg` calls.** `util.getArg(aArgs, 'original'|'source'|'name', null)` did a function call + an `'X' in aArgs` prototype-walk per call. Replaced with direct `aArgs.X != null ? aArgs.X : null` reads. Downstream code already uses `!= null` checks, so the undefined-vs-null distinction is moot. The required `generated` keeps `getArg` so the missing-arg throw is preserved when `_skipValidation` is true.

2. **Drop the redundant `has()` guard before `_sources.add` / `_names.add`.** `ArraySet.add` is already idempotent — it does its own `has()` check internally before pushing. The outer guard was just an extra function call. Net: 1 function call instead of 1 or 2 per add.

No public surface change.

## Bench

`scripts/bench-diff.sh main generate` (two-process, `SOLO=1 PHASES=adding,generate`, node v24.13.0):

| Fixture | Adding Δ | Generate Δ |
|---|---:|---:|
| amp.js.map | **+65%** | +3% |
| babel.min.js.map | **+41%** | -4% (within variance) |
| issue-41.js.map | **+112%** | -1% |
| preact.js.map | **+69%** | +6% |
| react.js.map | **+57%** | 0% |
| vscode.map | **+68%** | -2% |
| **mean** | **+69%** | +0.5% |

`Generate` deltas are within ±5% bench noise. `Adding` is consistently 40–112% faster.

## Tests

- All 180 existing tests pass.
- `yarn test:coverage` thresholds (98/97/96) green; `lib/source-map-generator.js` 100/100/100.