### PR TITLE
perf: inline optional getArg + hoist source in trace methods

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -219,7 +219,8 @@ SourceMapConsumer.prototype.allGeneratedPositionsFor =
     var needle = {
       source: util.getArg(aArgs, 'source'),
       originalLine: line,
-      originalColumn: util.getArg(aArgs, 'column', 0)
+      // `column` is optional, defaulted to 0. Inline the optional read.
+      originalColumn: aArgs.column != null ? aArgs.column : 0
     };
 
     needle.source = this._findSourceIndex(needle.source);
@@ -825,7 +826,9 @@ BasicSourceMapConsumer.prototype.originalPositionFor =
   function SourceMapConsumer_originalPositionFor(aArgs) {
     var needleLine = util.getArg(aArgs, 'line');
     var needleColumn = util.getArg(aArgs, 'column');
-    var bias = util.getArg(aArgs, 'bias', SourceMapConsumer.GREATEST_LOWER_BOUND);
+    // `bias` is optional, defaulted to GLB. Inline the optional read — every
+    // trace call paid for the getArg function-call overhead.
+    var bias = aArgs.bias != null ? aArgs.bias : SourceMapConsumer.GREATEST_LOWER_BOUND;
     var mappings = this._generatedMappings;
 
     var index = -1;
@@ -1026,7 +1029,8 @@ BasicSourceMapConsumer.prototype.generatedPositionFor =
 
     var needleLine = util.getArg(aArgs, 'line');
     var needleColumn = util.getArg(aArgs, 'column');
-    var bias = util.getArg(aArgs, 'bias', SourceMapConsumer.GREATEST_LOWER_BOUND);
+    // `bias` is optional, defaulted to GLB. Inline the optional read.
+    var bias = aArgs.bias != null ? aArgs.bias : SourceMapConsumer.GREATEST_LOWER_BOUND;
     var mappings = this._originalMappings;
 
     var index = -1;
@@ -1371,12 +1375,15 @@ IndexedSourceMapConsumer.prototype.sourceContentFor =
  */
 IndexedSourceMapConsumer.prototype.generatedPositionFor =
   function IndexedSourceMapConsumer_generatedPositionFor(aArgs) {
+    // Hoist the source read out of the per-section loop — used to be one
+    // util.getArg call per section iteration.
+    var argSource = util.getArg(aArgs, 'source');
     for (var i = 0; i < this._sections.length; i++) {
       var section = this._sections[i];
 
       // Only consider this section if the requested source is in the list of
       // sources of the consumer.
-      if (section.consumer._findSourceIndex(util.getArg(aArgs, 'source')) === -1) {
+      if (section.consumer._findSourceIndex(argSource) === -1) {
         continue;
       }
       var generatedPosition = section.consumer.generatedPositionFor(aArgs);


### PR DESCRIPTION
## Summary

Continuation of #59's pattern, applied to the per-query trace hot path.

Four sites, all in `lib/source-map-consumer.js`:

1. **`BasicSourceMapConsumer.originalPositionFor`** — `bias` is optional with default `GLB`. Replace `util.getArg(aArgs, 'bias', GLB)` with `aArgs.bias != null ? aArgs.bias : GLB`. Saves one function call + one `'bias' in aArgs` prototype-walk per trace.

2. **`BasicSourceMapConsumer.generatedPositionFor`** — same `bias` inline.

3. **`IndexedSourceMapConsumer.generatedPositionFor`** — hoist `util.getArg(aArgs, 'source')` out of the per-section loop (used to fire once per section iteration, now once per call).

4. **`SourceMapConsumer.allGeneratedPositionsFor`** — `column` is optional with default `0`, inlined the same way.

Required-arg `getArg` calls (line / column / source) are kept as-is to preserve the documented throw on missing args and avoid pushing uncovered throw branches into `source-map-consumer.js` (the `getArg` throw branch is reachable from many sites in `util.js`, so moving it inline would hurt branch coverage).

## Bench

`scripts/bench-diff.sh main trace` (two-process, `SOLO=1 PHASES=trace-random,trace-ascending,genpos-speed`, node v24.13.0):

| Fixture | Trace random Δ | Trace ascending Δ | genpos speed Δ |
|---|---:|---:|---:|
| amp.js.map | **+19.6%** | **+19.2%** | **+37.2%** |
| babel.min.js.map | +3.3% | **+14.9%** | +5.0% |
| issue-41.js.map | **+13.5%** | -4.7% (variance) | +9.0% |
| preact.js.map | **+21.9%** | **+19.7%** | **+12.6%** |
| react.js.map | **+17.4%** | **+15.9%** | +8.8% |
| vscode.map | **+16.5%** | **+20.4%** | -6.8% (variance) |
| **mean** | **+15%** | **+14%** | **+11%** |

Overall mean across 18 rows: **+13.5%**. Negative outliers (issue-41 ascending, vscode genpos-speed) are inside bench variance on the noisier fixtures with low ops counts.

## Tests

- All 180 existing tests pass.
- `yarn test:coverage` thresholds (98/97/96) green:
  - `lib/source-map-consumer.js`: 99.93 / 99.14 / 97.30
  - all files: 98.25 / 97.28 / 96.67