### PR TITLE
perf: inline lastGeneratedColumn getArg in trace return paths

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -250,7 +250,7 @@ SourceMapConsumer.prototype.allGeneratedPositionsFor =
           mappings.push({
             line: mapping.generatedLine,
             column: mapping.generatedColumn,
-            lastColumn: util.getArg(mapping, 'lastGeneratedColumn', null)
+            lastColumn: mapping.lastGeneratedColumn != null ? mapping.lastGeneratedColumn : null
           });
 
           mapping = this._originalMappings[++index];
@@ -268,7 +268,7 @@ SourceMapConsumer.prototype.allGeneratedPositionsFor =
           mappings.push({
             line: mapping.generatedLine,
             column: mapping.generatedColumn,
-            lastColumn: util.getArg(mapping, 'lastGeneratedColumn', null)
+            lastColumn: mapping.lastGeneratedColumn != null ? mapping.lastGeneratedColumn : null
           });
 
           mapping = this._originalMappings[++index];
@@ -1122,12 +1122,13 @@ BasicSourceMapConsumer.prototype.generatedPositionFor =
         }
 
         // generatedLine and generatedColumn are always set by _parseMappings;
-        // lastGeneratedColumn is added optionally by computeColumnSpans, so
-        // keep getArg there.
+        // lastGeneratedColumn is added optionally by computeColumnSpans, so a
+        // direct read with a null fallback covers both the missing and
+        // explicitly-null cases the same way getArg(...,'<f>',null) did.
         return {
           line: mapping.generatedLine,
           column: mapping.generatedColumn,
-          lastColumn: util.getArg(mapping, 'lastGeneratedColumn', null)
+          lastColumn: mapping.lastGeneratedColumn != null ? mapping.lastGeneratedColumn : null
         };
       }
     }


### PR DESCRIPTION
## Summary

Three more `util.getArg(mapping, 'lastGeneratedColumn', null)` sites — all in trace return paths:

- `BasicSourceMapConsumer.generatedPositionFor` (per-query return)
- `SourceMapConsumer.allGeneratedPositionsFor` (per-mapping in result, two inner loops)

Replaced with `mapping.lastGeneratedColumn != null ? mapping.lastGeneratedColumn : null`. Matches the existing `getArg(...,'<f>',null)` semantics exactly:

- present non-null value → returns the value
- explicitly null → returns null (the `!= null` check is false)
- missing field (undefined) → returns null

`lastGeneratedColumn` is only attached by `computeColumnSpans`, so for most consumers it's `undefined` and the inline avoids the function call + `'lastGeneratedColumn' in mapping` prototype-walk entirely.

## Bench

`scripts/bench-diff.sh main trace` (`SOLO=1 PHASES=genpos-speed`, node v24.13.0):

| Fixture | cand ops/sec | base ops/sec | Δ |
|---|---:|---:|---:|
| amp.js.map | 35.6k | 33.8k | **+5.2%** |
| babel.min.js.map | 5.40M | 5.12M | **+5.5%** |
| issue-41.js.map | 1.80M | 1.72M | **+4.6%** |
| preact.js.map | 595.8k | 569.1k | **+4.7%** |
| react.js.map | 7.23M | 7.21M | +0.3% |
| vscode.map | 1.2k | 1.0k | **+14.0%** |
| **mean** | | | **+5.7%** |

`originalPositionFor` (trace-random/trace-ascending) is unaffected by this PR — those paths don't read `lastGeneratedColumn`.

## Tests

- All 180 existing tests pass.
- `yarn test:coverage` thresholds (98/97/96) green:
  - `lib/source-map-consumer.js`: 99.93 / 98.31 / 97.30
  - all files: 98.25 / 97.01 / 96.67