### PR TITLE
perf: inline optional getArg in BasicSourceMapConsumer constructor

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -332,12 +332,13 @@ function BasicSourceMapConsumer(aSourceMap, aSourceMapURL) {
   var version = util.getArg(sourceMap, 'version');
   var sources = util.getArg(sourceMap, 'sources');
   // Sass 3.3 leaves out the 'names' array, so we deviate from the spec (which
-  // requires the array) to play nice here.
-  var names = util.getArg(sourceMap, 'names', []);
-  var sourceRoot = util.getArg(sourceMap, 'sourceRoot', null);
-  var sourcesContent = util.getArg(sourceMap, 'sourcesContent', null);
+  // requires the array) to play nice here. Inlined getArg with default for
+  // the optional fields below — see #59 for the pattern.
+  var names = sourceMap.names != null ? sourceMap.names : [];
+  var sourceRoot = sourceMap.sourceRoot != null ? sourceMap.sourceRoot : null;
+  var sourcesContent = sourceMap.sourcesContent != null ? sourceMap.sourcesContent : null;
   var mappings = util.getArg(sourceMap, 'mappings');
-  var file = util.getArg(sourceMap, 'file', null);
+  var file = sourceMap.file != null ? sourceMap.file : null;
 
   // Once again, Sass deviates from the spec and supplies the version as a
   // string rather than a number, so we use loose equality checking here.


### PR DESCRIPTION
## Summary

Counterpart to #62 — five `util.getArg(sourceMap, X, default)` sites in `BasicSourceMapConsumer()`:
- `names` (default `[]` — Sass 3.3 deviation)
- `sourceRoot` (default `null`)
- `sourcesContent` (default `null`)
- `file` (default `null`)

Replaced with `sourceMap.X != null ? sourceMap.X : default`. Same pattern as #59 / #60 / #62.

## Bench

Honest result: this one is a wash. Originally measured +1.1%; **re-benched after rebase onto main (with #64/#65/#66 landed)**: mean −0.49% across 12 init-bench rows, range −3.8% to +3.1% — within fixture variance.

Unlike #62 (where the SourceMapGenerator ctor inline saw +8.7% on `addMapping`, likely from V8 hidden-class effects helping the downstream per-mapping hot loop), the consumer ctor isn't followed by a hot loop in the same bench cycle. `_parseMappings` dominates init cost, so saving four function calls in the preamble is unmeasurable.

Keeping the change anyway for codebase consistency — without it, a future reader of #62 would have to wonder why one constructor was inlined and the other left alone.

`SOLO=1 PHASES=init scripts/bench-diff.sh main trace` (two-process, ops/sec via benchmark.js, after rebase):

| Fixture           | JSON cand     | JSON base     | JSON Δ | Object cand   | Object base   | Object Δ |
| ----------------- | ------------: | ------------: | -----: | ------------: | ------------: | -------: |
| amp.js.map        |    521 ±0.39% |    527 ±0.44% |  -1.1% |    617 ±0.43% |    641 ±0.29% |    -3.7% |
| babel.min.js.map  |     78.03     |     78.52     |  -0.6% |     91.38     |     89.74     |    +1.8% |
| issue-41.js.map   |    112 ±1.41% |    112 ±1.59% |   0.0% |    127 ±0.92% |    127 ±0.85% |     0.0% |
| preact.js.map     |  9,340 ±0.23% |  9,460 ±0.40% |  -1.3% | 18,566 ±0.51% | 19,292 ±0.30% |    -3.8% |
| react.js.map      |  5,605 ±0.59% |  5,691 ±0.34% |  -1.5% |  6,727 ±0.27% |  6,680 ±0.42% |    +0.7% |
| vscode.map        |   5.40 ±5.72% |   5.24 ±6.00% |  +3.1% |   7.15 ±5.58% |   7.11 ±9.18% |    +0.6% |
| **mean**          |               |               |        |               |               | **-0.49%** |

## Tests

- All 205 existing tests pass.
- `yarn test:coverage` thresholds (98/97/96) green:
  - `lib/source-map-consumer.js`: 99.93 / 98.34 / 97.30
  - all files: 98.35 / 97.21 / 96.75
- **No new tests needed** — the existing fixture set already exercises both branches of each default ternary, so coverage holds on its own.