### PR TITLE
perf: ArraySet.add returns index — drop trailing indexOf in hot paths

### DIFF
--- a/lib/array-set.js
+++ b/lib/array-set.js
@@ -44,22 +44,35 @@ ArraySet.prototype.size = function ArraySet_size() {
 /**
  * Add the given string to this set.
  *
+ * Returns the index of the string within the set: the existing index for a
+ * duplicate insert, or the new index for a fresh one. Hot generator/consumer
+ * paths use this return value to avoid a follow-up `indexOf` call (one Map
+ * lookup per mapping for source and one for name).
+ *
  * @param String aStr
  */
 ArraySet.prototype.add = function ArraySet_add(aStr, aAllowDuplicates) {
-  var sStr = hasNativeMap ? aStr : util.toSetString(aStr);
-  var isDuplicate = hasNativeMap ? this.has(aStr) : has.call(this._set, sStr);
-  var idx = this._array.length;
-  if (!isDuplicate || aAllowDuplicates) {
-    this._array.push(aStr);
-  }
-  if (!isDuplicate) {
-    if (hasNativeMap) {
-      this._set.set(aStr, idx);
-    } else {
-      this._set[sStr] = idx;
+  if (hasNativeMap) {
+    var existing = this._set.get(aStr);
+    if (existing !== undefined) {
+      if (aAllowDuplicates) this._array.push(aStr);
+      return existing;
     }
+    var idx = this._array.length;
+    this._array.push(aStr);
+    this._set.set(aStr, idx);
+    return idx;
   }
+  var sStr = util.toSetString(aStr);
+  if (has.call(this._set, sStr)) {
+    var existingIdx = this._set[sStr];
+    if (aAllowDuplicates) this._array.push(aStr);
+    return existingIdx;
+  }
+  var newIdx = this._array.length;
+  this._array.push(aStr);
+  this._set[sStr] = newIdx;
+  return newIdx;
 };
 
 /**

--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -1445,14 +1445,11 @@ IndexedSourceMapConsumer.prototype._parseMappings =
         if(source !== null) {
           source = util.computeSourceURL(section.consumer.sourceRoot, source, this._sourceMapURL);
         }
-        this._sources.add(source);
-        source = this._sources.indexOf(source);
+        source = this._sources.add(source);
 
         var name = null;
         if (mapping.name) {
-          name = section.consumer._names.at(mapping.name);
-          this._names.add(name);
-          name = this._names.indexOf(name);
+          name = this._names.add(section.consumer._names.at(mapping.name));
         }
 
         // The mappings coming from the consumer for the section have

--- a/lib/source-map-generator.js
+++ b/lib/source-map-generator.js
@@ -128,19 +128,16 @@ SourceMapGenerator.prototype.addMapping =
     }
 
     // Resolve source/name to integer indices once here so MappingList.add
-    // can store them as i32s in the slab. ArraySet.add is idempotent (its
-    // own has() check internally), and indexOf is a fast Map.get afterward.
+    // can store them as i32s in the slab. ArraySet.add returns the index
+    // (existing or new), so this is one Map op per source/name instead of
+    // the add+indexOf pair.
     var srcIdx = -1;
     if (source != null) {
-      source = String(source);
-      this._sources.add(source);
-      srcIdx = this._sources.indexOf(source);
+      srcIdx = this._sources.add(String(source));
     }
     var nameIdx = -1;
     if (name != null) {
-      name = String(name);
-      this._names.add(name);
-      nameIdx = this._names.indexOf(name);
+      nameIdx = this._names.add(String(name));
     }
 
     // _validateMapping enforces numeric original.line/column when original is
@@ -279,16 +276,8 @@ SourceMapGenerator.prototype.applySourceMap =
         }
       }
 
-      var newSrcIdx = -1;
-      if (source != null) {
-        newSources.add(source);
-        newSrcIdx = newSources.indexOf(source);
-      }
-      var newNameIdx = -1;
-      if (name != null) {
-        newNames.add(name);
-        newNameIdx = newNames.indexOf(name);
-      }
+      var newSrcIdx = source == null ? -1 : newSources.add(source);
+      var newNameIdx = name == null ? -1 : newNames.add(name);
 
       newMappings.add(genLine, genCol, origLine, origCol, newSrcIdx, newNameIdx);
     }


### PR DESCRIPTION
## Summary

`ArraySet.add` now returns the string's index in the set (existing or new). Three per-mapping hot paths previously paired `add()` with `indexOf()` to grab that index — that's two Map operations where one suffices. Letting `add` return it cuts the redundant `Map.get`.

Affected hot paths:
- `SourceMapGenerator.addMapping` — once per added mapping (source + name)
- `SourceMapGenerator.applySourceMap` — once per rebuilt mapping (source + name)
- `IndexedSourceMapConsumer._parseMappings` — once per section mapping (source + name)

## Bench

`SOLO=1 PHASES=adding scripts/bench-diff.sh main generate` (two-process, ops/sec via benchmark.js):

| fixture           | cand ops/sec       | base ops/sec       | Δ      |
| ----------------- | -----------------: | -----------------: | -----: |
| amp.js.map        |    559   ±0.45%    |    464   ±0.31%    | +20.5% |
| babel.min.js.map  |     68.90 ±0.92%   |     68.73 ±0.42%   |  +0.2% |
| issue-41.js.map   |    115   ±0.76%    |     85.30 ±0.79%   | +34.8% |
| preact.js.map     | 14,650   ±0.19%    | 11,247   ±0.13%    | +30.3% |
| react.js.map      |  4,969   ±0.19%    |  4,092   ±0.44%    | +21.4% |
| vscode.map        |      9.66 ±2.89%   |      7.98 ±3.04%   | +21.1% |

Sample sizes 24–100 runs per cell, error bars ≤3%. Mean **+21.4%**. babel.min is flat because it has very few unique sources/names — the saved `Map.get` is amortized away.

## API

`ArraySet.add` gains a return value (the index). Existing callers that ignore the return value continue to work unchanged — no breaking change.

## Test plan

- [x] All 205 tests pass
- [x] Coverage: 98.14 / 97.47 / 96.75 — above thresholds (98 / 97 / 96)