### PR TITLE
perf: skip null-context bind in eachMapping; direct names array read

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -173,8 +173,14 @@ SourceMapConsumer.prototype.eachMapping =
       throw new Error("Unknown order of iteration.");
     }
 
-    var boundCallback = aCallback.bind(context);
-    var names = this._names;
+    // Skip the `Function.prototype.bind` allocation when no context was
+    // supplied — `aCallback || null` defaults to a null context, which is
+    // the same as calling the function unbound.
+    var cb = context !== null ? aCallback.bind(context) : aCallback;
+    // Direct reads of the underlying `_array` slot match the slab-direct
+    // pattern in `_serializeMappings` / `fromSourceMap`. Skips the `at()`
+    // bounds-check + function call per named mapping.
+    var nameArray = this._names._array;
     // `_absoluteSources` is precomputed in both consumer constructors as
     // `computeSourceURL(sourceRoot, _sources.at(i), sourceMapURL)`, so a
     // direct index skips the per-call URL parse + resolve. Same memoization
@@ -183,13 +189,15 @@ SourceMapConsumer.prototype.eachMapping =
 
     for (var i = 0, n = mappings.length; i < n; i++) {
       var mapping = mappings[i];
-      boundCallback({
-        source: mapping.source === null ? null : absoluteSources[mapping.source],
+      var src = mapping.source;
+      var nm = mapping.name;
+      cb({
+        source: src === null ? null : absoluteSources[src],
         generatedLine: mapping.generatedLine,
         generatedColumn: mapping.generatedColumn,
         originalLine: mapping.originalLine,
         originalColumn: mapping.originalColumn,
-        name: mapping.name === null ? null : names.at(mapping.name)
+        name: nm === null ? null : nameArray[nm]
       });
     }
   };


### PR DESCRIPTION
## Summary

Three structural changes to the per-mapping `eachMapping` loop in `SourceMapConsumer`:

1. **Skip `aCallback.bind(context)` when `context === null`.** `Function.prototype.bind` produces a bound function V8 can't inline, so every per-mapping call dispatches through the internal `[[Call]]` path. With no context (the common case — both bench callsites and most consumers omit it), `bind` is pure overhead and the unbound `aCallback` inlines normally.

2. **Read `this._names._array` directly** instead of `this._names.at(idx)` per named mapping. Saves the bounds-check + function-call pair — matches the slab-direct pattern already used in `_serializeMappings` / `fromSourceMap`.

3. **Hoist `mapping.source` / `mapping.name` into locals** before building the result object. V8 should CSE this, but explicit locals are slightly more inline-friendly.

## Bench

`SOLO=1 PHASES=eachmapping-generated,eachmapping-original scripts/bench-diff.sh main trace` (two-process, ops/sec via benchmark.js):

| fixture           | order      | cand ops/sec    | base ops/sec    | Δ      |
| ----------------- | ---------- | --------------: | --------------: | -----: |
| amp.js.map        | generated  |  11,648 ±0.52%  |   3,505 ±8.05%  | +232.3% |
| amp.js.map        | original   |  11,783 ±0.70%  |   3,489 ±8.07%  | +237.7% |
| babel.min.js.map  | generated  |   1,191 ±0.80%  |     379 ±1.02%  | +214.2% |
| babel.min.js.map  | original   |   1,143 ±0.52%  |     383 ±1.07%  | +198.4% |
| issue-41.js.map   | generated  |   1,359 ±0.59%  |     428 ±1.03%  | +217.5% |
| issue-41.js.map   | original   |   1,366 ±0.70%  |     429 ±1.14%  | +218.4% |
| preact.js.map     | generated  | 301,487 ±0.30%  |  68,015 ±0.19%  | +343.3% |
| preact.js.map     | original   | 295,655 ±0.49%  |  66,782 ±0.29%  | +342.7% |
| react.js.map      | generated  | 106,632 ±0.40%  |  25,623 ±0.31%  | +316.2% |
| react.js.map      | original   |  89,972 ±0.28%  |  26,096 ±0.48%  | +244.8% |
| vscode.map        | generated  |     153 ±1.45%  |      56 ±?      | +173.4% |
| vscode.map        | original   |     150 ±0.76%  |      54 ±?      | +177.2% |

Mean **+243%** across 12 rows.

### Caveat on the headline number

The bench passes `NOOP` as the callback. With NOOP, the per-call cost is dominated by whatever happens *outside* the callback body, so the bound-vs-direct dispatch gap is fully exposed. With a real callback that does work, the proportional win shrinks (the callback body's cost is unchanged); the absolute time saved per call is the same. Baseline error bars on amp are ±8% vs candidate's ±0.5%, consistent with the bound-dispatch path being in a deopt/reopt cycle that the unbound path avoids.

## Test plan

- [x] All 205 tests pass
- [x] Coverage: 98.14 / 97.37 / 96.75 — above thresholds (98 / 97 / 96)