### PR TITLE
perf: inline GLB binary search in generatedPositionFor cold path

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -1115,19 +1115,54 @@ BasicSourceMapConsumer.prototype.generatedPositionFor =
     }
 
     if (index < 0) {
-      var needle = {
-        source: source,
-        originalLine: needleLine,
-        originalColumn: needleColumn
-      };
-      index = this._findMapping(
-        needle,
-        mappings,
-        "originalLine",
-        "originalColumn",
-        util.compareByOriginalPositions,
-        bias
-      );
+      if (bias === SourceMapConsumer.GREATEST_LOWER_BOUND) {
+        // Cold-path inline GLB binary search. _originalMappings is sorted by
+        // (source, originalLine, originalColumn). Direct field access avoids
+        // the indirect aCompare callback through binarySearch.search and
+        // skips the per-call {source, originalLine, originalColumn} needle
+        // allocation that the _findMapping call site otherwise pays.
+        var lo = -1;
+        var hi = mappings.length;
+        while (hi - lo > 1) {
+          var mid = (lo + hi) >>> 1;
+          var m = mappings[mid];
+          var cmp;
+          if (m.source !== source) cmp = m.source - source;
+          else if (m.originalLine !== needleLine) cmp = m.originalLine - needleLine;
+          else cmp = m.originalColumn - needleColumn;
+          if (cmp <= 0) lo = mid;
+          else hi = mid;
+        }
+        if (lo >= 0) {
+          // Rewind through any tie cluster to match binarySearch.search's
+          // smallest-equal semantics.
+          while (lo > 0) {
+            var cur = mappings[lo];
+            var prev = mappings[lo - 1];
+            if (prev.source !== cur.source ||
+                prev.originalLine !== cur.originalLine ||
+                prev.originalColumn !== cur.originalColumn) {
+              break;
+            }
+            lo--;
+          }
+          index = lo;
+        }
+      } else {
+        var needle = {
+          source: source,
+          originalLine: needleLine,
+          originalColumn: needleColumn
+        };
+        index = this._findMapping(
+          needle,
+          mappings,
+          "originalLine",
+          "originalColumn",
+          util.compareByOriginalPositions,
+          bias
+        );
+      }
     }
 
     if (index >= 0) {


### PR DESCRIPTION
## Summary

When `generatedPositionFor` misses the per-source warm cache and bias is GLB (the default), it falls through to `_findMapping` → `binarySearch.search` → `iterativeSearch` → `compareByOriginalPositions`. Profiling against `babel.min.js.map` showed `iterativeSearch` at **64% self-time** for random gpf probes — driven by the indirect `aCompare` callback at every step and the per-call `{source, originalLine, originalColumn}` needle allocation.

This PR inlines a GLB binary search with direct field access on `mappings[mid]` for the GLB cold path. The structure mirrors what `generatedPositionFor` already uses inside its cache-hit branch (`source-map-consumer.js:1088-1112`). LUB queries still go through `_findMapping` unchanged.

## Results

bench-diff vs `main`, SOLO, scoped to genpos phases:

| fixture | Generated Positions speed | init |
| --- | --- | --- |
| babel.min.js.map | 6.63M → 15.14M ops/sec (**+128%**) | flat (within ±2%) |
| issue-41.js.map | 1.95M → 5.45M ops/sec (**+180%**) | flat (within ±2%) |

CPU profile after the change confirms `iterativeSearch` is no longer in the top frames for the gpf scenario.

## Test plan

- [x] `yarn test` — 205/205 non-TODO tests pass; the 8 failures are pre-existing `# TODO` items unrelated to this change
- [x] `bench-diff.sh main trace` — full phase set on babel: only Generated Positions speed shifts; everything else within noise
- [x] CPU profile re-run on the gpf scenario confirms the hot frame is gone