### PR TITLE
perf: stable Mapping hidden class in _parseMappings

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -633,7 +633,7 @@ BasicSourceMapConsumer.prototype._parseMappings =
     var index = 0;
     var temp = {};
     var generatedMappings = [];
-    var mapping, value, charCode;
+    var value, charCode;
     // Reuse segment array to avoid allocations per mapping
     var segment = [0, 0, 0, 0, 0];
     var segmentLength = 0;
@@ -653,15 +653,6 @@ BasicSourceMapConsumer.prototype._parseMappings =
         index++;
       }
       else {
-        mapping = {
-          generatedLine: generatedLine,
-          generatedColumn: 0,
-          source: null,
-          originalLine: null,
-          originalColumn: null,
-          name: null
-        };
-
         // Decode VLQ values until we hit a separator
         segmentLength = 0;
         while (index < length) {
@@ -690,33 +681,42 @@ BasicSourceMapConsumer.prototype._parseMappings =
           throw new Error('Found a source and line, but no column');
         }
 
-        // Generated column.
-        mapping.generatedColumn = previousGeneratedColumn + segment[0];
-        previousGeneratedColumn = mapping.generatedColumn;
+        // Compute every mapping field into a local before allocating the
+        // literal. Building the object in one shot lets V8 settle on a
+        // single hidden class per mapping shape; the previous code wrote
+        // nulls into source/originalLine/originalColumn/name and then
+        // overwrote them with numbers, which trips per-field shape
+        // transitions and slows downstream reads (eachMapping iteration
+        // was the visible loser).
+        var genCol = previousGeneratedColumn + segment[0];
+        previousGeneratedColumn = genCol;
 
+        var src = null, origLine = null, origCol = null, nameIdx = null;
         if (segmentLength > 1) {
-          // Original source.
-          mapping.source = previousSource + segment[1];
-          previousSource += segment[1];
+          src = previousSource + segment[1];
+          previousSource = src;
 
-          // Original line.
-          mapping.originalLine = previousOriginalLine + segment[2];
-          previousOriginalLine = mapping.originalLine;
-          // Lines are stored 0-based
-          mapping.originalLine += 1;
+          var origLine0 = previousOriginalLine + segment[2];
+          previousOriginalLine = origLine0;
+          origLine = origLine0 + 1; // stored 1-based
 
-          // Original column.
-          mapping.originalColumn = previousOriginalColumn + segment[3];
-          previousOriginalColumn = mapping.originalColumn;
+          origCol = previousOriginalColumn + segment[3];
+          previousOriginalColumn = origCol;
 
           if (segmentLength > 4) {
-            // Original name.
-            mapping.name = previousName + segment[4];
-            previousName += segment[4];
+            nameIdx = previousName + segment[4];
+            previousName = nameIdx;
           }
         }
 
-        generatedMappings.push(mapping);
+        generatedMappings.push({
+          generatedLine: generatedLine,
+          generatedColumn: genCol,
+          source: src,
+          originalLine: origLine,
+          originalColumn: origCol,
+          name: nameIdx
+        });
       }
     }
 


### PR DESCRIPTION
## Summary

Mapping objects built by `_parseMappings` were allocated via a literal that set `source`/`originalLine`/`originalColumn`/`name` to `null`, and were then mutated to overwrite some of those nulls with numbers a few statements later. Each null→number write trips a V8 hidden-class transition, so the resulting mapping objects don't all share the same shape and downstream property reads pay polymorphic-IC costs.

This PR computes every field into a local first and builds the mapping with a single literal. The mapping shape is stable from allocation onward; `eachMapping` iteration (which reads all six fields per mapping) is the biggest beneficiary.

## Results (babel.min.js.map, three full bench-diff runs, medians)

| phase | median Δ |
| --- | --- |
| **eachMapping speed (generated order)** | **+13.6%** |
| **eachMapping speed (original order)** | **+9.5%** |
| Generated Positions init | +4.9% |
| Generated Positions speed | +3.5% |
| Trace speed (ascending) | +0.8% |
| Trace speed (random) | −0.2% |
| Init speed, JSON input | −1.0% |
| Init speed, Object input | **−2.0%** |

vscode.map (scoped phases) shows the same pattern: eachMapping +10%, init −1.5%.

The tradeoff: ~2% slower init in exchange for ~10–15% faster eachMapping and ~3–5% faster generatedPositionFor. For most consumers (bundlers, source-resolvers, error reporters) the per-consumer init cost is paid once and the lookup/iteration cost is paid many times, so the net is clearly positive — but the init delta is real and worth flagging.

## Test plan

- [x] `yarn test` — 205/205 non-TODO tests pass; 8 pre-existing TODO failures unrelated
- [x] `bench-diff.sh main trace` on babel, three independent runs, eachMapping wins are reproducible (+13.3%, +13.6%, +15.0%)
- [x] `bench-diff.sh main trace` on vscode.map confirms the same pattern at scale