### PR TITLE
perf: inline base64VLQ.decode slow path in _parseMappings

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -8,7 +8,12 @@
 var util = require('./util');
 var binarySearch = require('./binary-search');
 var ArraySet = require('./array-set').ArraySet;
-var base64VLQ = require('./base64-vlq');
+// `base64DecodeTable` maps a base64 character code → its 6-bit decoded value,
+// with `255` as the invalid-char sentinel. Imported directly so the inlined
+// multi-byte VLQ slow path in `_parseMappings` can index it without going
+// through a wrapper function — same direct-table pattern PR #67 applied to
+// `_names._array`.
+var base64DecodeTable = require('./base64').charToIntMap;
 
 function SourceMapConsumer(aSourceMap, aSourceMapURL) {
   var sourceMap = aSourceMap;
@@ -697,7 +702,6 @@ BasicSourceMapConsumer.prototype._parseMappings =
     var previousName = 0;
     var length = aStr.length;
     var index = 0;
-    var temp = {};
     var value, charCode;
     // Reuse segment array to avoid allocations per mapping
     var segment = [0, 0, 0, 0, 0];
@@ -738,10 +742,31 @@ BasicSourceMapConsumer.prototype._parseMappings =
             index++;
             segment[segmentLength++] = value;
           } else {
-            base64VLQ.decode(aStr, index, temp);
-            value = temp.value;
-            index = temp.rest;
-            segment[segmentLength++] = value;
+            // Multi-byte VLQ decode — inlined. Indirect-dispatched
+            // base64VLQ.decode + the temp output object's `.value`/`.rest`
+            // round trip is more cost than the body itself for typical
+            // small deltas. Bit layout: bit 0 = sign, bits 1-4 = value
+            // (chunked 5-bit groups across continuation digits), bit 5 =
+            // continuation. `base64DecodeTable[c] === 255` marks an
+            // invalid base64 char.
+            var vlqResult = 0;
+            var vlqShift = 0;
+            var vlqDigit;
+            do {
+              if (index >= length) {
+                throw new Error('Expected more digits in base 64 VLQ value.');
+              }
+              var vlqC = aStr.charCodeAt(index++);
+              vlqDigit = vlqC < 128 ? base64DecodeTable[vlqC] : 255;
+              if (vlqDigit === 255) {
+                throw new Error('Invalid base64 digit: ' + aStr.charAt(index - 1));
+              }
+              vlqResult = vlqResult + ((vlqDigit & 31) << vlqShift);
+              vlqShift += 5;
+            } while ((vlqDigit & 32) !== 0);
+            segment[segmentLength++] = (vlqResult & 1) === 1
+              ? -(vlqResult >> 1)
+              : (vlqResult >> 1);
           }
         }
 


### PR DESCRIPTION
## Summary

`_parseMappings` had one call site for `base64VLQ.decode` — the multi-byte VLQ slow path inside the inner decode loop — but the call site stayed boxed even after PRs #72 / #73 demonstrated that the function-call overhead at hot dispatch sites can be much larger than the profile's self-time share suggests. Inlining the body removes:

- the indirect function call,
- the temp output object's `.value` / `.rest` write/read round trip (and the `temp = {}` allocation at parse start),
- the inner `fromVLQSigned` call,

so the slow path stays in `_parseMappings`'s frame and V8 can specialize across the call boundary.

The `base64DecodeTable` (= `base64.charToIntMap`) is now imported directly in `source-map-consumer.js`, paralleling the `_names._array` direct-index pattern from PR #67.

## Results (bench-diff vs main, SOLO)

### babel.min.js.map (full-phase, single run)

| phase | Δ |
| --- | --- |
| **Init speed, JSON input** | **+9.0%** |
| **Init speed, Object input** | **+5.8%** |
| Trace speed (random) | +6.3% |
| Trace speed (ascending) | +2.2% |
| Generated Positions init | +4.5% |
| Generated Positions speed | +4.0% |
| eachMapping speed (generated order) | +4.5% |
| eachMapping speed (original order) | +3.8% |
| **mean** | **+4.99%** |

Three init-only runs reproduce: Init JSON +2.6% / +3.3% / +4.0%, Init Object +0.9% / +1.8% / +1.9%. The full-phase run is higher (+5–9%) likely because of V8 IC sharing — once the parse function is simpler, downstream callers warm up cleaner.

### vscode.map (init only, 3 runs)

| run | JSON input | Object input |
| --- | --- | --- |
| 1 | +1.9% | 0.0% |
| 2 | +1.2% | −0.3% |
| 3 | +0.1% | −0.7% |

Very small / neutral on vscode. babel's win comes from cleaner VLQ distribution; vscode is more memory-bound.

## Test plan

- [x] `yarn test` — 205/205 non-TODO tests pass
- [x] Three babel init runs reproduce the +2-4% init gain
- [x] Full-phase babel run shows positive deltas across all 8 phases (mean +5%) with no regressions
- [x] vscode init runs are neutral (no regression)